### PR TITLE
Expose Env#getMaxKeySize

### DIFF
--- a/src/main/java/org/lmdbjava/Env.java
+++ b/src/main/java/org/lmdbjava/Env.java
@@ -62,12 +62,15 @@ public final class Env<T> implements AutoCloseable {
   private final BufferProxy<T> proxy;
   private final Pointer ptr;
   private final boolean readOnly;
+  private final int maxKeySize;
 
   private Env(final BufferProxy<T> proxy, final Pointer ptr,
               final boolean readOnly) {
     this.proxy = proxy;
     this.readOnly = readOnly;
     this.ptr = ptr;
+    // cache max key size to avoid further JNI calls
+    this.maxKeySize = LIB.mdb_env_get_maxkeysize(ptr);
   }
 
   /**
@@ -152,6 +155,15 @@ public final class Env<T> implements AutoCloseable {
     checkRc(LIB.mdb_env_copy2(ptr, path.getAbsolutePath(), flagsMask));
   }
 
+  /**
+   * Get the maximum size of keys and MDB_DUPSORT data we can write.
+   * 
+   * @return the maximum size of keys.
+   */
+  public int getMaxKeySize() {
+    return maxKeySize;
+  }
+  
   /**
    * Return information about this environment.
    *

--- a/src/test/java/org/lmdbjava/ByteBufferProxyTest.java
+++ b/src/test/java/org/lmdbjava/ByteBufferProxyTest.java
@@ -121,7 +121,8 @@ public final class ByteBufferProxyTest {
   }
 
   private void checkInOut(final BufferProxy<ByteBuffer> v) {
-    final ByteBuffer b = allocateDirect(511);
+    // allocate a buffer larger than max key size
+    final ByteBuffer b = allocateDirect(1000);
     b.putInt(1);
     b.putInt(2);
     b.putInt(3);

--- a/src/test/java/org/lmdbjava/EnvTest.java
+++ b/src/test/java/org/lmdbjava/EnvTest.java
@@ -202,6 +202,8 @@ public final class EnvTest {
     assertThat(info.mapSize, is(123_456L));
     assertThat(info.maxReaders, is(4));
     assertThat(info.numReaders, is(0));
+    
+    assertThat(env.getMaxKeySize(), is(511));
   }
 
   @Test


### PR DESCRIPTION
511 bytes should not be a magic constant.