### PR TITLE
improve transaction state machine

### DIFF
--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -118,7 +118,7 @@ public final class Dbi<T> {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
       requireNonNull(key);
-      txn.checkNotCommitted();
+      txn.checkReady();
       txn.checkWritesAllowed();
     }
 
@@ -146,7 +146,7 @@ public final class Dbi<T> {
   public void drop(final Txn<T> txn) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
-      txn.checkNotCommitted();
+      txn.checkReady();
       txn.checkWritesAllowed();
     }
     checkRc(LIB.mdb_drop(txn.pointer(), ptr, 0));
@@ -171,7 +171,7 @@ public final class Dbi<T> {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
       requireNonNull(key);
-      txn.checkNotCommitted();
+      txn.checkReady();
     }
     txn.keyIn(key);
     final int rc = LIB.mdb_get(txn.pointer(), ptr, txn.pointerKey(), txn.
@@ -227,7 +227,7 @@ public final class Dbi<T> {
                                    final IteratorType type) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
-      txn.checkNotCommitted();
+      txn.checkReady();
     }
     return new CursorIterator<>(openCursor(txn), key, type);
   }
@@ -251,7 +251,7 @@ public final class Dbi<T> {
   public Cursor<T> openCursor(final Txn<T> txn) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
-      txn.checkNotCommitted();
+      txn.checkReady();
     }
     final PointerByReference cursorPtr = new PointerByReference();
     checkRc(LIB.mdb_cursor_open(txn.pointer(), ptr, cursorPtr));
@@ -293,7 +293,7 @@ public final class Dbi<T> {
       requireNonNull(txn);
       requireNonNull(key);
       requireNonNull(val);
-      txn.checkNotCommitted();
+      txn.checkReady();
       txn.checkWritesAllowed();
     }
     txn.keyIn(key);
@@ -324,7 +324,7 @@ public final class Dbi<T> {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
       requireNonNull(key);
-      txn.checkNotCommitted();
+      txn.checkReady();
       txn.checkWritesAllowed();
     }
     txn.keyIn(key);
@@ -345,7 +345,7 @@ public final class Dbi<T> {
   public Stat stat(final Txn<T> txn) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
-      txn.checkNotCommitted();
+      txn.checkReady();
     }
     final MDB_stat stat = new MDB_stat(RUNTIME);
     checkRc(LIB.mdb_stat(txn.pointer(), ptr, stat));

--- a/src/test/java/org/lmdbjava/CursorTest.java
+++ b/src/test/java/org/lmdbjava/CursorTest.java
@@ -58,7 +58,7 @@ import static org.lmdbjava.TestUtils.POSIX_MODE;
 import static org.lmdbjava.TestUtils.bb;
 import static org.lmdbjava.TestUtils.mdb;
 import static org.lmdbjava.TestUtils.nb;
-import org.lmdbjava.Txn.CommittedException;
+import org.lmdbjava.Txn.NotReadyException;
 import org.lmdbjava.Txn.ReadOnlyRequiredException;
 
 /**
@@ -131,7 +131,7 @@ public final class CursorTest {
     cursorByteBuffer(PROXY_SAFE);
   }
 
-  @Test(expected = CommittedException.class)
+  @Test(expected = NotReadyException.class)
   public void cursorCannotCloseIfTransactionCommitted() {
     final Env<ByteBuffer> env = makeEnv(PROXY_OPTIMAL);
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE, MDB_DUPSORT);

--- a/src/test/java/org/lmdbjava/TxnTest.java
+++ b/src/test/java/org/lmdbjava/TxnTest.java
@@ -43,14 +43,15 @@ import static org.lmdbjava.EnvFlags.MDB_RDONLY_ENV;
 import static org.lmdbjava.TestUtils.DB_1;
 import static org.lmdbjava.TestUtils.POSIX_MODE;
 import static org.lmdbjava.TestUtils.bb;
-import org.lmdbjava.Txn.CommittedException;
 import org.lmdbjava.Txn.EnvIsReadOnly;
 import org.lmdbjava.Txn.IncompatibleParent;
+import org.lmdbjava.Txn.NotReadyException;
 import org.lmdbjava.Txn.NotResetException;
 import org.lmdbjava.Txn.ReadOnlyRequiredException;
 import org.lmdbjava.Txn.ReadWriteRequiredException;
 import org.lmdbjava.Txn.ResetException;
 import static org.lmdbjava.TxnFlags.MDB_RDONLY_TXN;
+import static org.lmdbjava.Txn.State.*;
 
 /**
  * Test {@link Txn}.
@@ -94,11 +95,11 @@ public final class TxnTest {
     roEnv.txnWrite(); // error
   }
 
-  @Test(expected = CommittedException.class)
+  @Test(expected = NotReadyException.class)
   public void testCheckNotCommitted() {
     final Txn<ByteBuffer> txn = env.txnRead();
     txn.commit();
-    txn.checkNotCommitted();
+    txn.checkReady();
   }
 
   @Test(expected = ReadOnlyRequiredException.class)
@@ -136,23 +137,23 @@ public final class TxnTest {
   @Test
   public void txCanCommitThenCloseWithoutError() {
     try (final Txn<ByteBuffer> txn = env.txnRead()) {
-      assertThat(txn.isCommitted(), is(false));
+      assertThat(txn.getState(), is(READY));
       txn.commit();
-      assertThat(txn.isCommitted(), is(true));
+      assertThat(txn.getState(), is(FINISHED));
     }
   }
 
-  @Test(expected = CommittedException.class)
+  @Test(expected = NotReadyException.class)
   public void txCannotAbortIfAlreadyCommitted() {
     try (final Txn<ByteBuffer> txn = env.txnRead()) {
-      assertThat(txn.isCommitted(), is(false));
+      assertThat(txn.getState(), is(READY));
       txn.commit();
-      assertThat(txn.isCommitted(), is(true));
+      assertThat(txn.getState(), is(FINISHED));
       txn.abort();
     }
   }
 
-  @Test(expected = CommittedException.class)
+  @Test(expected = NotReadyException.class)
   public void txCannotCommitTwice() {
     final Txn<ByteBuffer> txn = env.txnRead();
     txn.commit();
@@ -190,29 +191,32 @@ public final class TxnTest {
   public void txReadOnly() {
     final Txn<ByteBuffer> txn = env.txnRead();
     assertThat(txn.getParent(), is(nullValue()));
-    assertThat(txn.isCommitted(), is(false));
+    assertThat(txn.getState(), is(READY));
     assertThat(txn.isReadOnly(), is(true));
-    assertThat(txn.isReset(), is(false));
-    txn.checkNotCommitted();
+    txn.checkReady();
     txn.checkReadOnly();
     txn.reset();
-    assertThat(txn.isReset(), is(true));
+    assertThat(txn.getState(), is(RESET));
     txn.renew();
-    assertThat(txn.isReset(), is(false));
+    assertThat(txn.getState(), is(READY));
     txn.commit();
-    assertThat(txn.isCommitted(), is(true));
+    assertThat(txn.getState(), is(FINISHED));
+    txn.close();
+    assertThat(txn.getState(), is(RELEASED));
   }
 
   @Test
   public void txReadWrite() {
     final Txn<ByteBuffer> txn = env.txnWrite();
     assertThat(txn.getParent(), is(nullValue()));
-    assertThat(txn.isCommitted(), is(false));
+    assertThat(txn.getState(), is(READY));
     assertThat(txn.isReadOnly(), is(false));
-    txn.checkNotCommitted();
+    txn.checkReady();
     txn.checkWritesAllowed();
     txn.commit();
-    assertThat(txn.isCommitted(), is(true));
+    assertThat(txn.getState(), is(FINISHED));
+    txn.close();
+    assertThat(txn.getState(), is(RELEASED));
   }
 
   @Test(expected = NotResetException.class)

--- a/src/test/java/org/lmdbjava/TxnTest.java
+++ b/src/test/java/org/lmdbjava/TxnTest.java
@@ -139,7 +139,7 @@ public final class TxnTest {
     try (final Txn<ByteBuffer> txn = env.txnRead()) {
       assertThat(txn.getState(), is(READY));
       txn.commit();
-      assertThat(txn.getState(), is(FINISHED));
+      assertThat(txn.getState(), is(DONE));
     }
   }
 
@@ -148,7 +148,7 @@ public final class TxnTest {
     try (final Txn<ByteBuffer> txn = env.txnRead()) {
       assertThat(txn.getState(), is(READY));
       txn.commit();
-      assertThat(txn.getState(), is(FINISHED));
+      assertThat(txn.getState(), is(DONE));
       txn.abort();
     }
   }
@@ -200,7 +200,7 @@ public final class TxnTest {
     txn.renew();
     assertThat(txn.getState(), is(READY));
     txn.commit();
-    assertThat(txn.getState(), is(FINISHED));
+    assertThat(txn.getState(), is(DONE));
     txn.close();
     assertThat(txn.getState(), is(RELEASED));
   }
@@ -214,7 +214,7 @@ public final class TxnTest {
     txn.checkReady();
     txn.checkWritesAllowed();
     txn.commit();
-    assertThat(txn.getState(), is(FINISHED));
+    assertThat(txn.getState(), is(DONE));
     txn.close();
     assertThat(txn.getState(), is(RELEASED));
   }


### PR DESCRIPTION
Addresses #15.

Breaks a test case using Netty `ByteBuf` for some reason, but since I’m not familiar with how that’s supposed to work, I’m submitting as is.