### PR TITLE
Cursors get their own key and value buffers

### DIFF
--- a/src/main/java/org/lmdbjava/Cursor.java
+++ b/src/main/java/org/lmdbjava/Cursor.java
@@ -279,8 +279,10 @@ public final class Cursor<T> implements AutoCloseable {
       newTxn.checkReadOnly();
       newTxn.checkReady();
     }
-    checkRc(LIB.mdb_cursor_renew(newTxn.pointer(), ptrCursor));
-    this.txn = newTxn;
+    if (this.txn != newTxn) {
+      checkRc(LIB.mdb_cursor_renew(newTxn.pointer(), ptrCursor));
+      this.txn = newTxn;
+    }
   }
 
   /**

--- a/src/main/java/org/lmdbjava/Txn.java
+++ b/src/main/java/org/lmdbjava/Txn.java
@@ -44,9 +44,9 @@ import static org.lmdbjava.TxnFlags.MDB_RDONLY_TXN;
 public final class Txn<T> implements AutoCloseable {
 
   private static final MemoryManager MEM_MGR = RUNTIME.getMemoryManager();
+  final BufferProxy<T> proxy;
   private T k;
   private final Txn<T> parent;
-  private final BufferProxy<T> proxy;
   private final Pointer ptr;
   private final Pointer ptrKey;
   private final long ptrKeyAddr;

--- a/src/test/java/org/lmdbjava/CursorParamTest.java
+++ b/src/test/java/org/lmdbjava/CursorParamTest.java
@@ -121,33 +121,33 @@ public final class CursorParamTest {
           // check MDB_SET operations
           final T key3 = set(3);
           assertThat(c.get(key3, MDB_SET_KEY), is(true));
-          assertThat(get(txn.key()), is(3));
-          assertThat(get(txn.val()), is(4));
+          assertThat(get(c.key()), is(3));
+          assertThat(get(c.val()), is(4));
           final T key6 = set(6);
           assertThat(c.get(key6, MDB_SET_RANGE), is(true));
-          assertThat(get(txn.key()), is(7));
+          assertThat(get(c.key()), is(7));
           if (!(this instanceof ByteArrayRunner)) {
-            assertThat(get(txn.val()), is(8));
+            assertThat(get(c.val()), is(8));
           }
           final T key999 = set(999);
           assertThat(c.get(key999, MDB_SET_KEY), is(false));
 
           // check MDB navigation operations
           assertThat(c.seek(MDB_LAST), is(true));
-          final int mdb1 = get(txn.key());
-          final int mdb2 = get(txn.val());
+          final int mdb1 = get(c.key());
+          final int mdb2 = get(c.val());
 
           assertThat(c.seek(MDB_PREV), is(true));
-          final int mdb3 = get(txn.key());
-          final int mdb4 = get(txn.val());
+          final int mdb3 = get(c.key());
+          final int mdb4 = get(c.val());
 
           assertThat(c.seek(MDB_NEXT), is(true));
-          final int mdb5 = get(txn.key());
-          final int mdb6 = get(txn.val());
+          final int mdb5 = get(c.key());
+          final int mdb6 = get(c.val());
 
           assertThat(c.seek(MDB_FIRST), is(true));
-          final int mdb7 = get(txn.key());
-          final int mdb8 = get(txn.val());
+          final int mdb7 = get(c.key());
+          final int mdb8 = get(c.val());
 
           // assert afterwards to ensure memory address from LMDB
           // are valid within same txn and across cursor movement

--- a/src/test/java/org/lmdbjava/CursorTest.java
+++ b/src/test/java/org/lmdbjava/CursorTest.java
@@ -131,21 +131,21 @@ public final class CursorTest {
       c.put(bb(7), bb(8));
 
       assertThat(c.first(), is(true));
-      assertThat(txn.key().getInt(0), is(1));
-      assertThat(txn.val().getInt(0), is(2));
+      assertThat(c.key().getInt(0), is(1));
+      assertThat(c.val().getInt(0), is(2));
 
       assertThat(c.last(), is(true));
-      assertThat(txn.key().getInt(0), is(7));
-      assertThat(txn.val().getInt(0), is(8));
+      assertThat(c.key().getInt(0), is(7));
+      assertThat(c.val().getInt(0), is(8));
 
       assertThat(c.prev(), is(true));
-      assertThat(txn.key().getInt(0), is(5));
-      assertThat(txn.val().getInt(0), is(6));
+      assertThat(c.key().getInt(0), is(5));
+      assertThat(c.val().getInt(0), is(6));
 
       assertThat(c.first(), is(true));
       assertThat(c.next(), is(true));
-      assertThat(txn.key().getInt(0), is(3));
-      assertThat(txn.val().getInt(0), is(4));
+      assertThat(c.key().getInt(0), is(3));
+      assertThat(c.val().getInt(0), is(4));
     }
   }
 
@@ -157,12 +157,12 @@ public final class CursorTest {
       c.put(bb(1), bb(2), MDB_NOOVERWRITE);
       c.put(bb(3), bb(4));
       assertThat(c.seek(MDB_FIRST), is(true));
-      assertThat(txn.key().getInt(), is(1));
-      assertThat(txn.val().getInt(), is(2));
+      assertThat(c.key().getInt(), is(1));
+      assertThat(c.val().getInt(), is(2));
       c.delete();
       assertThat(c.seek(MDB_FIRST), is(true));
-      assertThat(txn.key().getInt(), is(3));
-      assertThat(txn.val().getInt(), is(4));
+      assertThat(c.key().getInt(), is(3));
+      assertThat(c.val().getInt(), is(4));
       c.delete();
       assertThat(c.seek(MDB_FIRST), is(false));
     }

--- a/src/test/java/org/lmdbjava/TutorialTest.java
+++ b/src/test/java/org/lmdbjava/TutorialTest.java
@@ -252,17 +252,17 @@ public final class TutorialTest {
 
       // We can read from the Cursor by key.
       c.get(key, MDB_SET);
-      assertThat(UTF_8.decode(txn.key()).toString(), is("ccc"));
+      assertThat(UTF_8.decode(c.key()).toString(), is("ccc"));
 
       // Let's see that LMDB provides the keys in appropriate order....
       c.seek(MDB_FIRST);
-      assertThat(UTF_8.decode(txn.key()).toString(), is("aaa"));
+      assertThat(UTF_8.decode(c.key()).toString(), is("aaa"));
 
       c.seek(MDB_LAST);
-      assertThat(UTF_8.decode(txn.key()).toString(), is("zzz"));
+      assertThat(UTF_8.decode(c.key()).toString(), is("zzz"));
 
       c.seek(MDB_PREV);
-      assertThat(UTF_8.decode(txn.key()).toString(), is("ccc"));
+      assertThat(UTF_8.decode(c.key()).toString(), is("ccc"));
 
       // Cursors can also delete the current key.
       c.delete();
@@ -388,13 +388,13 @@ public final class TutorialTest {
 
       // Let's position the Cursor. Note sorting still works.
       c.seek(MDB_FIRST);
-      assertThat(UTF_8.decode(txn.val()).toString(), is("kkk"));
+      assertThat(UTF_8.decode(c.val()).toString(), is("kkk"));
 
       c.seek(MDB_LAST);
-      assertThat(UTF_8.decode(txn.val()).toString(), is("xxx"));
+      assertThat(UTF_8.decode(c.val()).toString(), is("xxx"));
 
       c.seek(MDB_PREV);
-      assertThat(UTF_8.decode(txn.val()).toString(), is("lll"));
+      assertThat(UTF_8.decode(c.val()).toString(), is("lll"));
 
       c.close();
       txn.commit();
@@ -436,11 +436,11 @@ public final class TutorialTest {
       c.put(key, val);
 
       c.seek(MDB_FIRST);
-      assertThat(txn.key().getStringWithoutLengthUtf8(0, env.getMaxKeySize()),
+      assertThat(c.key().getStringWithoutLengthUtf8(0, env.getMaxKeySize()),
                  startsWith("ggg"));
 
       c.seek(MDB_LAST);
-      assertThat(txn.key().getStringWithoutLengthUtf8(0, env.getMaxKeySize()),
+      assertThat(c.key().getStringWithoutLengthUtf8(0, env.getMaxKeySize()),
                  startsWith("yyy"));
 
       // DirectBuffer has no notion of a position. Often you don't want to store
@@ -454,8 +454,8 @@ public final class TutorialTest {
       assertThat(key.capacity(), is(keyLen));
       c.put(key, val);
       c.seek(MDB_FIRST);
-      assertThat(txn.key().capacity(), is(keyLen));
-      assertThat(txn.key().getStringWithoutLengthUtf8(0, txn.key().capacity()),
+      assertThat(c.key().capacity(), is(keyLen));
+      assertThat(c.key().getStringWithoutLengthUtf8(0, c.key().capacity()),
                  is("12characters"));
 
       // If we want to store bigger values again, just wrap our original buffer.


### PR DESCRIPTION
This allows to concurrently use the same read transaction with multiple cursors (related to conversation in #35). 

@krisskross Thanks for the suggestion of changing the cursors to have their own buffers. I'm now using this in my own project and it fits the "concurrent reads on same version" use case perfectly. I'm not sure how to best handle the proxy access, currently using the one from Txn. There's also some code duplication with proxy usage in Txn. If you're interested in helping me make this merge-ready I'd be happy to make changes.