### PR TITLE
Add allDbiNames() and openAllDbi to Env

### DIFF
--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -20,6 +20,8 @@
 
 package org.lmdbjava;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import static java.util.Objects.requireNonNull;
 import static jnr.ffi.Memory.allocateDirect;
 import static jnr.ffi.NativeType.ADDRESS;
@@ -50,14 +52,23 @@ public final class Dbi<T> {
   private final String name;
   private final Pointer ptr;
 
-  Dbi(final Env<T> env, final Txn<T> txn, final String name,
+  Dbi(final Env<T> env, final Txn<?> txn, final String name,
       final DbiFlags... flags) {
+    final Pointer dbiPtr = allocateDirect(RUNTIME, ADDRESS);
+    checkRc(LIB.mdb_dbi_open(txn.pointer(), name, mask(flags), dbiPtr));
     this.env = env;
     this.name = name;
-    final int flagsMask = mask(flags);
+    this.ptr = dbiPtr.getPointer(0);
+  }
+
+  Dbi(final Env<T> env, final Txn<?> txn, final String name,
+      final Charset charset, final DbiFlags... flags) {
     final Pointer dbiPtr = allocateDirect(RUNTIME, ADDRESS);
-    checkRc(LIB.mdb_dbi_open(txn.pointer(), name, flagsMask, dbiPtr));
-    ptr = dbiPtr.getPointer(0);
+    final ByteBuffer nameBB = ByteBuffer.wrap(name.getBytes(charset));
+    checkRc(LIB.mdb_dbi_open(txn.pointer(), nameBB, mask(flags), dbiPtr));
+    this.env = env;
+    this.name = name;
+    this.ptr = dbiPtr.getPointer(0);
   }
 
   /**
@@ -249,9 +260,10 @@ public final class Dbi<T> {
    * {@link Cursor#renew(org.lmdbjava.Txn)} before finally closing it.
    *
    * @param txn transaction handle (not null; not committed)
+   * @param <B> The buffer type
    * @return cursor handle
    */
-  public Cursor<T> openCursor(final Txn<T> txn) {
+  public <B> Cursor<B> openCursor(final Txn<B> txn) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
       txn.checkReady();

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import static java.lang.Boolean.getBoolean;
 import static java.lang.System.getProperty;
 import static java.lang.Thread.currentThread;
+import java.nio.ByteBuffer;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static jnr.ffi.LibraryLoader.create;
@@ -199,8 +200,13 @@ final class Library {
 
     int mdb_dbi_flags(@In Pointer txn, @In Pointer dbi, int flags);
 
+    // Open the database using the system default encoding of the name
     int mdb_dbi_open(@In Pointer txn, @In String name, int flags,
                      @In Pointer dbiPtr);
+
+    // Open the database using raw bytes for the name
+    int mdb_dbi_open(@In Pointer txn, @In ByteBuffer name, int flags,
+        @In Pointer dbiPtr);
 
     int mdb_del(@In Pointer txn, @In Pointer dbi, @In Pointer key,
                 @In Pointer data);

--- a/src/main/java/org/lmdbjava/Txn.java
+++ b/src/main/java/org/lmdbjava/Txn.java
@@ -48,7 +48,7 @@ public final class Txn<T> implements AutoCloseable {
   private final boolean readOnly;
   private State state;
 
-  Txn(final Env<T> env, final Txn<T> parent, final BufferProxy<T> proxy,
+  Txn(final Env<?> env, final Txn<T> parent, final BufferProxy<T> proxy,
       final TxnFlags... flags) {
     this.proxy = proxy;
     this.keyVal = proxy.keyVal();


### PR DESCRIPTION
fixes #37 

This change adds two methods to `Env` to access all known `Dbi`s.

Because the buffer type is generic, it is not possible to use the buffer type parameter of the Env to access the Dbi names.  Thus, I used the BufferProxy<byte[]> to access the data and produce the String names.

This required loosening up the generic types somewhat, but it makes sense to me.  Overall the buffer type parameter is far more coupled between `Env` `Dbi` and `Cursor` and `Txn` than it needs to be.  In many more cases it could become a generic parameter on a method rather than coupled to the instance.

The tests pass for me locally, but it is unclear if UTF-8 is explicitly used or is a system dependent thing.    If it is system dependent, then that means the system dependence is persisted to disk and this becomes a problem / caveat.