### PR TITLE
Put: Special flag handling and Cursor/Dbi alignment

### DIFF
--- a/src/main/java/org/lmdbjava/Cursor.java
+++ b/src/main/java/org/lmdbjava/Cursor.java
@@ -202,7 +202,6 @@ public final class Cursor<T> implements AutoCloseable {
    */
   public boolean put(final T key, final T val, final PutFlags... op) {
     if (SHOULD_CHECK) {
-      requireNonNull(txn);
       requireNonNull(key);
       requireNonNull(val);
       checkNotClosed();
@@ -221,10 +220,9 @@ public final class Cursor<T> implements AutoCloseable {
         checkRc(rc);
       }
       return false;
-    } else {
-      checkRc(rc);
-      return true;
     }
+    checkRc(rc);
+    return true;
   }
 
   /**

--- a/src/main/java/org/lmdbjava/Cursor.java
+++ b/src/main/java/org/lmdbjava/Cursor.java
@@ -23,10 +23,15 @@ package org.lmdbjava;
 import static java.util.Objects.requireNonNull;
 import jnr.ffi.Pointer;
 import jnr.ffi.byref.NativeLongByReference;
+
+import static org.lmdbjava.Dbi.KeyExistsException.MDB_KEYEXIST;
 import static org.lmdbjava.Dbi.KeyNotFoundException.MDB_NOTFOUND;
 import static org.lmdbjava.Env.SHOULD_CHECK;
 import static org.lmdbjava.Library.LIB;
+import static org.lmdbjava.MaskedFlag.isSet;
 import static org.lmdbjava.MaskedFlag.mask;
+import static org.lmdbjava.PutFlags.MDB_NODUPDATA;
+import static org.lmdbjava.PutFlags.MDB_NOOVERWRITE;
 import static org.lmdbjava.PutFlags.MDB_RESERVE;
 import static org.lmdbjava.ResultCodeMapper.checkRc;
 import static org.lmdbjava.SeekOp.MDB_FIRST;
@@ -187,15 +192,17 @@ public final class Cursor<T> implements AutoCloseable {
    * Store by cursor.
    *
    * <p>
-   * This function stores key/data pairs into the database. The cursor is
-   * positioned at the new item, or on failure usually near it.
+   * This function stores key/data pairs into the database.
    *
    * @param key key to store
    * @param val data to store
    * @param op  options for this operation
+   * @return true if the value was put, false if MDB_NOOVERWRITE or
+   *     MDB_NODUPDATA were set and the key/value existed already.
    */
-  public void put(final T key, final T val, final PutFlags... op) {
+  public boolean put(final T key, final T val, final PutFlags... op) {
     if (SHOULD_CHECK) {
+      requireNonNull(txn);
       requireNonNull(key);
       requireNonNull(val);
       checkNotClosed();
@@ -204,11 +211,20 @@ public final class Cursor<T> implements AutoCloseable {
     }
     kv.keyIn(key);
     kv.valIn(val);
-    final int flags = mask(op);
-    checkRc(LIB.mdb_cursor_put(ptrCursor, kv.pointerKey(), kv.pointerVal(),
-                               flags));
-    kv.keyOut();
-    kv.valOut();
+    final int mask = mask(op);
+    final int rc = LIB.mdb_cursor_put(ptrCursor, kv.pointerKey(), kv.pointerVal(),
+                               mask);
+    if (rc == MDB_KEYEXIST) {
+      if (isSet(mask, MDB_NOOVERWRITE)) {
+        kv.valOut(); // marked as in,out in LMDB C docs
+      } else if (!isSet(mask, MDB_NODUPDATA)) {
+        checkRc(rc);
+      }
+      return false;
+    } else {
+      checkRc(rc);
+      return true;
+    }
   }
 
   /**

--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -35,6 +35,7 @@ import org.lmdbjava.Library.MDB_stat;
 import static org.lmdbjava.Library.RUNTIME;
 import static org.lmdbjava.MaskedFlag.isSet;
 import static org.lmdbjava.MaskedFlag.mask;
+import static org.lmdbjava.PutFlags.MDB_NODUPDATA;
 import static org.lmdbjava.PutFlags.MDB_NOOVERWRITE;
 import static org.lmdbjava.PutFlags.MDB_RESERVE;
 import static org.lmdbjava.ResultCodeMapper.checkRc;
@@ -289,8 +290,10 @@ public final class Dbi<T> {
    * @param key   key to store in the database (not null)
    * @param val   value to store in the database (not null)
    * @param flags Special options for this operation
+   * @return true if the value was put, false if MDB_NOOVERWRITE or
+   *     MDB_NODUPDATA were set and the key/value existed already.
    */
-  public void put(final Txn<T> txn, final T key, final T val,
+  public boolean put(final Txn<T> txn, final T key, final T val,
                   final PutFlags... flags) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
@@ -304,10 +307,17 @@ public final class Dbi<T> {
     final int mask = mask(flags);
     final int rc = LIB.mdb_put(txn.pointer(), ptr, txn.kv().pointerKey(), txn
                                .kv().pointerVal(), mask);
-    if (rc == MDB_KEYEXIST && isSet(mask, MDB_NOOVERWRITE)) {
-      txn.kv().valOut(); // marked as in,out in LMDB C docs
+    if (rc == MDB_KEYEXIST) {
+      if (isSet(mask, MDB_NOOVERWRITE)) {
+        txn.kv().valOut(); // marked as in,out in LMDB C docs
+      } else if (!isSet(mask, MDB_NODUPDATA)) {
+        checkRc(rc);
+      }
+      return false;
+    } else {
+      checkRc(rc);
+      return true;
     }
-    checkRc(rc);
   }
 
   /**

--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -314,10 +314,9 @@ public final class Dbi<T> {
         checkRc(rc);
       }
       return false;
-    } else {
-      checkRc(rc);
-      return true;
     }
+    checkRc(rc);
+    return true;
   }
 
   /**

--- a/src/main/java/org/lmdbjava/MaskedFlag.java
+++ b/src/main/java/org/lmdbjava/MaskedFlag.java
@@ -21,6 +21,7 @@
 package org.lmdbjava;
 
 import static java.util.Objects.requireNonNull;
+import static org.lmdbjava.Env.SHOULD_CHECK;
 
 /**
  * Indicates an enum that can provide integers for each of its values.
@@ -64,7 +65,9 @@ public interface MaskedFlag {
    * @return true if set.
    */
   static boolean isSet(final int flags, final MaskedFlag test) {
-    requireNonNull(test);
+    if (SHOULD_CHECK) {
+      requireNonNull(test);
+    }
     return (flags & test.getMask()) == test.getMask();
   }
 }

--- a/src/main/java/org/lmdbjava/MaskedFlag.java
+++ b/src/main/java/org/lmdbjava/MaskedFlag.java
@@ -65,9 +65,7 @@ public interface MaskedFlag {
    * @return true if set.
    */
   static boolean isSet(final int flags, final MaskedFlag test) {
-    if (SHOULD_CHECK) {
-      requireNonNull(test);
-    }
+    requireNonNull(test);
     return (flags & test.getMask()) == test.getMask();
   }
 }

--- a/src/main/java/org/lmdbjava/MaskedFlag.java
+++ b/src/main/java/org/lmdbjava/MaskedFlag.java
@@ -21,7 +21,6 @@
 package org.lmdbjava;
 
 import static java.util.Objects.requireNonNull;
-import static org.lmdbjava.Env.SHOULD_CHECK;
 
 /**
  * Indicates an enum that can provide integers for each of its values.

--- a/src/test/java/org/lmdbjava/CursorTest.java
+++ b/src/test/java/org/lmdbjava/CursorTest.java
@@ -42,6 +42,7 @@ import static org.lmdbjava.DbiFlags.MDB_DUPSORT;
 import static org.lmdbjava.Env.create;
 import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
 import static org.lmdbjava.PutFlags.MDB_APPENDDUP;
+import static org.lmdbjava.PutFlags.MDB_NODUPDATA;
 import static org.lmdbjava.PutFlags.MDB_NOOVERWRITE;
 import static org.lmdbjava.SeekOp.MDB_FIRST;
 import static org.lmdbjava.TestUtils.DB_1;
@@ -195,6 +196,31 @@ public final class CursorTest {
     }
   }
 
+  @Test
+  public void returnValueForNoOverwrite() {
+    final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE);
+    try (Txn<ByteBuffer> txn = env.txnWrite()) {
+      final Cursor<ByteBuffer> c = db.openCursor(txn);
+      // ok
+      assertThat(c.put(bb(5), bb(6), MDB_NOOVERWRITE), is(true)); 
+      // fails, but gets exist val
+      assertThat(c.put(bb(5), bb(8), MDB_NOOVERWRITE), is(false));
+      assertThat(c.val().getInt(0), is(6));
+    }
+  }
+
+  @Test
+  public void returnValueForNoDupData() {
+    final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE, MDB_DUPSORT);
+    try (Txn<ByteBuffer> txn = env.txnWrite()) {
+      final Cursor<ByteBuffer> c = db.openCursor(txn);
+      // ok
+      assertThat(c.put(bb(5), bb(6), MDB_NODUPDATA), is(true));
+      assertThat(c.put(bb(5), bb(7), MDB_NODUPDATA), is(true));
+      assertThat(c.put(bb(5), bb(6), MDB_NODUPDATA), is(false));
+    }
+  }
+  
   @Test
   public void repeatedCloseCausesNotError() {
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE, MDB_DUPSORT);

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -43,7 +43,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.lmdbjava.Dbi.DbFullException;
-import org.lmdbjava.Dbi.KeyExistsException;
 import static org.lmdbjava.DbiFlags.MDB_CREATE;
 import static org.lmdbjava.DbiFlags.MDB_DUPSORT;
 import org.lmdbjava.Env.MapFullException;
@@ -120,17 +119,15 @@ public final class DbiTest {
     assertThat(db.getName(), is(DB_1));
   }
 
-  @Test(expected = KeyExistsException.class)
+  @Test
   public void keyExistsException() {
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE);
     try (Txn<ByteBuffer> txn = env.txnWrite()) {
-      db.put(txn, bb(5), bb(6), MDB_NOOVERWRITE); // ok
-      try {
-        db.put(txn, bb(5), bb(8), MDB_NOOVERWRITE); // fails, but gets exist val
-      } catch (final KeyExistsException ke) {
-        assertThat(txn.val().getInt(0), is(6));
-        throw ke;
-      }
+      // ok
+      assertThat(db.put(txn, bb(5), bb(6), MDB_NOOVERWRITE), is(true)); 
+      // fails, but gets exist val
+      assertThat(db.put(txn, bb(5), bb(8), MDB_NOOVERWRITE), is(false));
+      assertThat(txn.val().getInt(0), is(6));
     }
   }
 

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -50,6 +50,7 @@ import static org.lmdbjava.Env.create;
 import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
 import static org.lmdbjava.GetOp.MDB_SET_KEY;
 import org.lmdbjava.LmdbNativeException.ConstantDerviedException;
+import static org.lmdbjava.PutFlags.MDB_NODUPDATA;
 import static org.lmdbjava.PutFlags.MDB_NOOVERWRITE;
 import static org.lmdbjava.TestUtils.DB_1;
 import static org.lmdbjava.TestUtils.ba;
@@ -120,7 +121,7 @@ public final class DbiTest {
   }
 
   @Test
-  public void keyExistsException() {
+  public void returnValueForNoOverwrite() {
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE);
     try (Txn<ByteBuffer> txn = env.txnWrite()) {
       // ok
@@ -131,6 +132,17 @@ public final class DbiTest {
     }
   }
 
+  @Test
+  public void returnValueForNoDupData() {
+    final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE, MDB_DUPSORT);
+    try (Txn<ByteBuffer> txn = env.txnWrite()) {
+      // ok
+      assertThat(db.put(txn, bb(5), bb(6), MDB_NODUPDATA), is(true));
+      assertThat(db.put(txn, bb(5), bb(7), MDB_NODUPDATA), is(true));
+      assertThat(db.put(txn, bb(5), bb(6), MDB_NODUPDATA), is(false));
+    }
+  }
+  
   @Test
   public void putAbortGet() {
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE);


### PR DESCRIPTION
The MDB_NOOVERWRITE and MDB_NODUPDATA flags now return false to communicate when the put operation was not executed (instead of slow exceptions). The semantics of Cursor.put are now fully aligned with Dbi.put. Added tests to cover both special cases.