### PR TITLE
delete on non-exsistent keys returns false instead of throwing exception

### DIFF
--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -81,12 +81,15 @@ public final class Dbi<T> {
    * Starts a new read-write transaction and deletes the key.
    *
    * @param key key to delete from the database (not null)
+   * @return true if the key/data pair was found, false otherwise
+   * 
    * @see #delete(org.lmdbjava.Txn, java.lang.Object, java.lang.Object)
    */
-  public void delete(final T key) {
+  public boolean delete(final T key) {
     try (Txn<T> txn = env.txnWrite()) {
-      delete(txn, key);
+      boolean ret = delete(txn, key);
       txn.commit();
+      return ret;
     }
   }
 
@@ -95,10 +98,12 @@ public final class Dbi<T> {
    *
    * @param txn transaction handle (not null; not committed; must be R-W)
    * @param key key to delete from the database (not null)
+   * @return true if the key/data pair was found, false otherwise
+   * 
    * @see #delete(org.lmdbjava.Txn, java.lang.Object, java.lang.Object)
    */
-  public void delete(final Txn<T> txn, final T key) {
-    delete(txn, key, null);
+  public boolean delete(final Txn<T> txn, final T key) {
+    return delete(txn, key, null);
   }
 
   /**
@@ -111,15 +116,12 @@ public final class Dbi<T> {
    * the duplicate data items for the key will be deleted. Otherwise, if the
    * data parameter is non-null only the matching data item will be deleted.
    *
-   * <p>
-   * This function will throw {@link KeyNotFoundException} if the key/data pair
-   * is not found.
-   *
    * @param txn transaction handle (not null; not committed; must be R-W)
    * @param key key to delete from the database (not null)
    * @param val value to delete from the database (null permitted)
+   * @return true if the key/data pair was found, false otherwise
    */
-  public void delete(final Txn<T> txn, final T key, final T val) {
+  public boolean delete(final Txn<T> txn, final T key, final T val) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
       requireNonNull(key);
@@ -129,14 +131,17 @@ public final class Dbi<T> {
 
     txn.kv().keyIn(key);
 
-    if (val == null) {
-      checkRc(LIB.mdb_del(txn.pointer(), ptr, txn.kv().pointerKey(), null));
-    } else {
+    Pointer data = null;
+    if (val != null) {
       txn.kv().valIn(val);
-      checkRc(LIB
-          .mdb_del(txn.pointer(), ptr, txn.kv().pointerKey(), txn.kv()
-                   .pointerVal()));
+      data = txn.kv().pointerVal();
     }
+    int rc = LIB.mdb_del(txn.pointer(), ptr, txn.kv().pointerKey(), data);
+    if (rc == MDB_NOTFOUND) {
+        return false;
+    }
+    checkRc(rc);
+    return true;
   }
 
   /**

--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -87,7 +87,7 @@ public final class Dbi<T> {
    */
   public boolean delete(final T key) {
     try (Txn<T> txn = env.txnWrite()) {
-      boolean ret = delete(txn, key);
+      final boolean ret = delete(txn, key);
       txn.commit();
       return ret;
     }
@@ -136,9 +136,9 @@ public final class Dbi<T> {
       txn.kv().valIn(val);
       data = txn.kv().pointerVal();
     }
-    int rc = LIB.mdb_del(txn.pointer(), ptr, txn.kv().pointerKey(), data);
+    final int rc = LIB.mdb_del(txn.pointer(), ptr, txn.kv().pointerKey(), data);
     if (rc == MDB_NOTFOUND) {
-        return false;
+      return false;
     }
     checkRc(rc);
     return true;

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -166,7 +166,8 @@ public final class DbiTest {
       assertNotNull(found);
       assertThat(txn.val().getInt(), is(5));
     }
-    db.delete(bb(5));
+    assertThat(db.delete(bb(5)), is(true));
+    assertThat(db.delete(bb(5)), is(false));
 
     try (Txn<ByteBuffer> txn = env.txnRead()) {
       assertNull(db.get(txn, bb(5)));
@@ -215,7 +216,7 @@ public final class DbiTest {
 
     try (Txn<ByteBuffer> txn = env.txnWrite()) {
       db.put(txn, bb(5), bb(5));
-      db.delete(txn, bb(5));
+      assertThat(db.delete(txn, bb(5)), is(true));
 
       assertNull(db.get(txn, bb(5)));
       txn.abort();
@@ -230,12 +231,15 @@ public final class DbiTest {
       db.put(txn, bb(5), bb(5));
       db.put(txn, bb(5), bb(6));
       db.put(txn, bb(5), bb(7));
-      db.delete(txn, bb(5), bb(6));
+      assertThat(db.delete(txn, bb(5), bb(6)), is(true));
+      assertThat(db.delete(txn, bb(5), bb(6)), is(false));
+      assertThat(db.delete(txn, bb(5), bb(5)), is(true));
+      assertThat(db.delete(txn, bb(5), bb(5)), is(false));
 
       try (Cursor<ByteBuffer> cursor = db.openCursor(txn)) {
         final ByteBuffer key = bb(5);
         cursor.get(key, MDB_SET_KEY);
-        assertThat(cursor.count(), is(2L));
+        assertThat(cursor.count(), is(1L));
       }
       txn.abort();
     }


### PR DESCRIPTION
Fixes #44.