### PR TITLE
Add custom configurable external native library path setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.lmdbjava</groupId>
   <artifactId>lmdbjava</artifactId>
-  <version>0.0.5</version>
+  <version>0.0.5_2</version>
   <packaging>jar</packaging>
   <name>LmdbJava</name>
   <description>Low latency Java API for the ultra-fast, embedded Symas Lightning Database (LMDB)</description>
@@ -45,7 +45,7 @@
     <connection>scm:git:git@github.com:${github.org}/${github.repo}.git</connection>
     <developerConnection>scm:git:git@github.com:${github.org}/${github.repo}.git</developerConnection>
     <url>git@github.com:${github.org}/${github.repo}.git</url>
-    <tag>lmdbjava-0.0.5</tag>
+    <tag>lmdbjava-0.0.5_2</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issues</system>
@@ -56,8 +56,8 @@
     <url>https://travis-ci.org/${github.org}/${github.repo}</url>
   </ciManagement>
   <properties>
-    <github.org>lmdbjava</github.org>
-    <github.repo>lmdbjava</github.repo>
+    <github.org>Maurice-Betzel</github.org>
+    <github.repo>lmdb-java</github.repo>
     <license.licenseName>apache_v2</license.licenseName>
   </properties>
   <dependencies>

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -59,12 +59,13 @@ final class Library {
    * avoiding the library copy etc).
    */
   public static final String DISABLE_EXTRACT_PROP = "lmdbjava.disable.extract";
-
+  public static final String OSGI_NATIVE_LMDB_PROP = "osgi.native.lmdb";
   /**
    * Indicates whether automatic extraction of the LMDB system library is
    * permitted.
    */
   public static final boolean SHOULD_EXTRACT = !getBoolean(DISABLE_EXTRACT_PROP);
+  public static final boolean OSGI_ENVIRONMENT = !getBoolean(DISABLE_EXTRACT_PROP);
 
   static final Lmdb LIB;
   static final jnr.ffi.Runtime RUNTIME;
@@ -88,6 +89,8 @@ final class Library {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
     } else if (SHOULD_EXTRACT && arch64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
+    } else if (OSGI_ENVIRONMENT) {
+      libToLoad = getProperty(OSGI_NATIVE_LMDB_PROP);
     } else {
       libToLoad = LIB_NAME;
     }

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -65,7 +65,7 @@ final class Library {
    * permitted.
    */
   public static final boolean SHOULD_EXTRACT = !getBoolean(DISABLE_EXTRACT_PROP);
-  public static final boolean OSGI_ENVIRONMENT = !getBoolean(DISABLE_EXTRACT_PROP);
+  public static final boolean OSGI_ENVIRONMENT = !getBoolean(OSGI_NATIVE_LMDB_PROP);
 
   static final Lmdb LIB;
   static final jnr.ffi.Runtime RUNTIME;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -66,12 +66,14 @@ final class Library {
    * LMDB system library.
    */
   public static final String LMDB_NATIVE_LIB_PROP = "lmdbjava.native.lib";
-
   /**
    * Indicates whether automatic extraction of the LMDB system library is
    * permitted.
    */
   static final boolean SHOULD_EXTRACT = !getBoolean(DISABLE_EXTRACT_PROP);
+  /**
+   * Indicates whether external LMDB system library is provided.
+   */
   static final boolean SHOULD_USE_LIB = !getBoolean(LMDB_NATIVE_LIB_PROP);
 
   static final Lmdb LIB;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -59,13 +59,20 @@ final class Library {
    * avoiding the library copy etc).
    */
   public static final String DISABLE_EXTRACT_PROP = "lmdbjava.disable.extract";
-  public static final String OSGI_NATIVE_LMDB_PROP = "osgi.native.lmdb";
+  /**
+   * Java system property name that can be set to provide a custom path to a
+   * external LMDB system library. If set, the system property
+   * DISABLE_EXTRACT_PROP must also be set to avoid extraction of the internal
+   * LMDB system library.
+   */
+  public static final String LMDB_NATIVE_LIB_PROP = "lmdbjava.native.lib";
+
   /**
    * Indicates whether automatic extraction of the LMDB system library is
    * permitted.
    */
-  public static final boolean SHOULD_EXTRACT = !getBoolean(DISABLE_EXTRACT_PROP);
-  public static final boolean OSGI_ENVIRONMENT = !getBoolean(OSGI_NATIVE_LMDB_PROP);
+  static final boolean SHOULD_EXTRACT = !getBoolean(DISABLE_EXTRACT_PROP);
+  static final boolean SHOULD_USE_LIB = !getBoolean(LMDB_NATIVE_LIB_PROP);
 
   static final Lmdb LIB;
   static final jnr.ffi.Runtime RUNTIME;
@@ -89,8 +96,8 @@ final class Library {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
     } else if (SHOULD_EXTRACT && arch64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
-    } else if (OSGI_ENVIRONMENT) {
-      libToLoad = getProperty(OSGI_NATIVE_LMDB_PROP);
+    } else if (SHOULD_USE_LIB) {
+      libToLoad = getProperty(LMDB_NATIVE_LIB_PROP);
     } else {
       libToLoad = LIB_NAME;
     }


### PR DESCRIPTION
Added a Java system property name that can be set to provide a custom path to a external LMDB system library. If set, the system property DISABLE_EXTRACT_PROP must also be set to avoid extraction of the internal LMDB system library.