### PR TITLE
Made KeyVal public to support using iterators outside of the package

### DIFF
--- a/src/main/java/org/lmdbjava/KeyVal.java
+++ b/src/main/java/org/lmdbjava/KeyVal.java
@@ -32,7 +32,7 @@ import static org.lmdbjava.Library.RUNTIME;
  *
  * @param <T> buffer type
  */
-final class KeyVal<T> implements AutoCloseable {
+public final class KeyVal<T> implements AutoCloseable {
 
   private static final MemoryManager MEM_MGR = RUNTIME.getMemoryManager();
   private boolean closed;


### PR DESCRIPTION
KeyVal is used in src/test/java/org/lmdbjava/TutorialTest.java to demonstrate iterating over the entire collection. This does not work for client code, since KeyVal is currently package protected.