### PR TITLE
Add support for listing Dbi flags

### DIFF
--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -222,7 +222,7 @@ final class Library {
 
     void mdb_dbi_close(@In Pointer env, @In Pointer dbi);
 
-    int mdb_dbi_flags(@In Pointer txn, @In Pointer dbi, int flags);
+    int mdb_dbi_flags(@In Pointer txn, @In Pointer dbi, @Out Pointer flags);
 
     int mdb_dbi_open(@In Pointer txn, @In byte[] name, int flags,
                      @In Pointer dbiPtr);

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import org.junit.After;
@@ -62,6 +63,7 @@ import static org.lmdbjava.ByteBufferProxy.PROXY_OPTIMAL;
 import org.lmdbjava.Dbi.DbFullException;
 import static org.lmdbjava.DbiFlags.MDB_CREATE;
 import static org.lmdbjava.DbiFlags.MDB_DUPSORT;
+import static org.lmdbjava.DbiFlags.MDB_REVERSEKEY;
 import org.lmdbjava.Env.MapFullException;
 import static org.lmdbjava.Env.create;
 import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
@@ -473,5 +475,15 @@ public final class DbiTest {
             db.put(bb(random.nextInt()), bb(random.nextInt()));
           }
         });
+  }
+
+  @Test
+  public void listsFlags() {
+    final Dbi<ByteBuffer> dbi = env.openDbi(DB_1, MDB_CREATE, MDB_DUPSORT, MDB_REVERSEKEY);
+
+    try (Txn<ByteBuffer> txn = env.txnRead()) {
+      final List<DbiFlags> flags = dbi.listFlags(txn);
+      assertThat(flags, containsInAnyOrder(MDB_DUPSORT, MDB_REVERSEKEY));
+    }
   }
 }


### PR DESCRIPTION
I've added support for the `mdb_dbi_flags` call. We are using this in our project to inspect which flags a Dbi was created with. In particular we have a piece of code to copy an entire DB re-writing the keys in an ordered fashion to reduce wasted space (within the pages). For this we need to know what flags the new DB needs creating with and if we need to set `MDB_APPEND ` or `MDB_APPENDDUP ` when inserting into our copied DB.