### PR TITLE
Added support for aarch64 and ppc64le binaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
     </dependency>
     <dependency>
       <groupId>org.lmdbjava</groupId>
+      <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
+      <version>0.9.24-2-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.lmdbjava</groupId>
       <artifactId>lmdbjava-native-linux-x86_64</artifactId>
       <version>0.9.24-1</version>
       <optional>true</optional>
@@ -118,6 +124,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-ppc64le</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
@@ -149,6 +156,7 @@
             <configuration>
               <artifactSet>
                 <includes>
+                  <include>org.lmdbjava:lmdbjava-native-linux-ppc64le</include>
                   <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
     </dependency>
     <dependency>
       <groupId>org.lmdbjava</groupId>
+      <artifactId>lmdbjava-native-linux-aarch64</artifactId>
+      <version>0.9.24-2-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.lmdbjava</groupId>
       <artifactId>lmdbjava-native-linux-x86_64</artifactId>
       <version>0.9.24-1</version>
       <optional>true</optional>
@@ -112,6 +118,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
@@ -142,6 +149,7 @@
             <configuration>
               <artifactSet>
                 <includes>
+                  <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -105,6 +105,7 @@ final class Library {
     final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
     final boolean aarch64 = "aarch64".equals(arch);
+    final boolean ppc64le = "ppc64le".equals(arch);
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -115,6 +116,8 @@ final class Library {
       libToLoad = getProperty(LMDB_NATIVE_LIB_PROP);
     } else if (SHOULD_EXTRACT && aarch64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
+    } else if (SHOULD_EXTRACT && ppc64le && linux) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-ppc64le.so");
     } else if (SHOULD_EXTRACT && arch64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
     } else if (SHOULD_EXTRACT && arch64 && osx) {

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -107,7 +107,7 @@ final class Library {
     final boolean aarch64 = "aarch64".equals(arch);
     final boolean ppc64le = "ppc64le".equals(arch);
 
-    final boolean arch64 = x64 || aarch64 || ppc64le;
+    // final boolean arch64 = x64 || aarch64 || ppc64le;
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -102,10 +102,12 @@ final class Library {
     final String libToLoad;
 
     final String arch = getProperty("os.arch");
-    final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
+    final boolean x86_64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
     final boolean aarch64 = "aarch64".equals(arch);
     final boolean ppc64le = "ppc64le".equals(arch);
+
+    final boolean arch64 = x86_64 || aarch64 || ppc64le;
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -118,11 +120,11 @@ final class Library {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
     } else if (SHOULD_EXTRACT && ppc64le && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-ppc64le.so");
-    } else if (SHOULD_EXTRACT && arch64 && linux) {
+    } else if (SHOULD_EXTRACT && x86_64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
-    } else if (SHOULD_EXTRACT && arch64 && osx) {
+    } else if (SHOULD_EXTRACT && x86_64 && osx) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
-    } else if (SHOULD_EXTRACT && arch64 && windows) {
+    } else if (SHOULD_EXTRACT && x86_64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
     } else {
       libToLoad = LIB_NAME;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -102,12 +102,12 @@ final class Library {
     final String libToLoad;
 
     final String arch = getProperty("os.arch");
-    final boolean x86_64 = "x64".equals(arch) || "amd64".equals(arch)
+    final boolean x64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
     final boolean aarch64 = "aarch64".equals(arch);
     final boolean ppc64le = "ppc64le".equals(arch);
 
-    final boolean arch64 = x86_64 || aarch64 || ppc64le;
+    final boolean arch64 = x64 || aarch64 || ppc64le;
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -120,11 +120,11 @@ final class Library {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
     } else if (SHOULD_EXTRACT && ppc64le && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-ppc64le.so");
-    } else if (SHOULD_EXTRACT && x86_64 && linux) {
+    } else if (SHOULD_EXTRACT && x64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
-    } else if (SHOULD_EXTRACT && x86_64 && osx) {
+    } else if (SHOULD_EXTRACT && x64 && osx) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
-    } else if (SHOULD_EXTRACT && x86_64 && windows) {
+    } else if (SHOULD_EXTRACT && x64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
     } else {
       libToLoad = LIB_NAME;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -104,6 +104,7 @@ final class Library {
     final String arch = getProperty("os.arch");
     final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
+    final boolean aarch64 = "aarch64".equals(arch);
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -112,6 +113,8 @@ final class Library {
 
     if (SHOULD_USE_LIB) {
       libToLoad = getProperty(LMDB_NATIVE_LIB_PROP);
+    } else if (SHOULD_EXTRACT && aarch64 && linux) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
     } else if (SHOULD_EXTRACT && arch64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
     } else if (SHOULD_EXTRACT && arch64 && osx) {


### PR DESCRIPTION
This PR is using new libraries created  in https://github.com/lmdbjava/native/pull/7 .
The usage for this "secondary architecture" is now somethng like:
```
  ARCH=`uname -p`
 ...
    if [ "$ARCH" == "x86_64" ] ; then
     mvn clean install -P linux-x86_64 -P \!linux
    elif  [ "$ARCH" == "aarch64" ] ; then
      mvn clean install -P linux-aarch64 -P \!linux
    elif  [ "$ARCH" == "ppc64le" ] ; then
      mvn clean install -P linux-ppc64le -P \!linux
   else 
     echo "Not building native, invalid or other upstream-supported platform."
  ...
```
Whole concept seems to be working, with two glitches:
 - optional for native jars do not work, so even when building solemn aarch64 you need the ppc64le (as they are not yet in maven repos) and similiarly you need aarch64 when building ppc64le, and yo need them both when you are now building gneric linux profiles  (looking for advice in this topic)
   - you can easily fake them, but it is dangerous
 - Second issue is more scary. Unit tests fails on both ppc64le and aarch64. I tried both with head and the crucial commit of lmdb of 0c357cc88a00bda03aa4a982fc227a5872707df2 . On contrary intel is not failing also with head lmdb.

I have to be doing something wrong, or lmdbjava must be doing somethng I faild to discover, as lmdb itself seems to work fine on aarch64/ppc64le. Both based on linux ditributions usages and on unittests.


ERROR] Failures: 
[ERROR]   DbiTest.stats:460 
Expected: is <4096>
     but: was <32768>
[ERROR]   EnvTest.stats:393 
Expected: is <4096>
     but: was <32768>
[ERROR] Errors: 
[ERROR]   CursorIterableTest.before:132 » MapFull Environment mapsize reached (-30792)
... Skipped 11 identical lines...
[ERROR]   CursorIterableTest.before:132 » MapFull Environment mapsize reached (-30792)
[ERROR]   EnvTest.setMapSize:341 » MapFull Environment mapsize reached (-30792)
[ERROR]   TxnTest.largeKeysRejected »  Unexpected exception, expected<org.lmdbjava.Dbi$B...
[ERROR]   TxnTest.rangeSearch:103 » MapFull Environment mapsize reached (-30792)
[ERROR]   TxnTest.readOnlyTxnAllowedInReadOnlyEnv:138 » MapFull Environment mapsize reac...
[ERROR]   TxnTest.readWriteTxnDeniedInReadOnlyEnv »  Unexpected exception, expected<org....
[ERROR]   TxnTest.testGetId:181 » MapFull Environment mapsize reached (-30792)
[ERROR]   TxnTest.zeroByteKeysRejected »  Unexpected exception, expected<org.lmdbjava.Db...
[INFO] 
[ERROR] Tests run: 187, Failures: 2, Errors: 31, Skipped: 0


Before i spam OpenLDAP, do you have any idea what may be going on?
