### PR TITLE
Ports to aarch64 and ppc64le systems with OS pages 65536 bytes big

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,18 +72,6 @@
     </dependency>
     <dependency>
       <groupId>org.lmdbjava</groupId>
-      <artifactId>lmdbjava-native-linux-aarch64</artifactId>
-      <version>0.9.24-2-SNAPSHOT</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.lmdbjava</groupId>
-      <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
-      <version>0.9.24-2-SNAPSHOT</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.lmdbjava</groupId>
       <artifactId>lmdbjava-native-linux-x86_64</artifactId>
       <version>0.9.24-1</version>
       <optional>true</optional>
@@ -124,8 +112,6 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <usedDependency>org.lmdbjava:lmdbjava-native-linux-ppc64le</usedDependency>
-            <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
@@ -156,8 +142,6 @@
             <configuration>
               <artifactSet>
                 <includes>
-                  <include>org.lmdbjava:lmdbjava-native-linux-ppc64le</include>
-                  <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>
@@ -232,4 +216,126 @@
     <system>GitHub Actions</system>
     <url>https://github.com/${github.org}/${github.repo}/actions</url>
   </ciManagement>
+  <profiles>
+    <profile>
+      <id>linux-aarch64</id>
+      <activation>
+        <os>
+          <name>Linux</name>
+          <family>unix</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.lmdbjava</groupId>
+          <artifactId>lmdbjava-native-linux-aarch64</artifactId>
+          <version>0.9.24-2-SNAPSHOT</version>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <configuration>
+              <usedDependencies>
+                <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
+              </usedDependencies>
+              <ignoredDependencies>
+                <ignoredDependency>com.github.jnr:jffi</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>lmdbjava-shade</id>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
+                      <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
+                      <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
+                      <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>linux-ppc64le</id>
+      <activation>
+        <os>
+          <name>Linux</name>
+          <family>unix</family>
+          <arch>ppc64le</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.lmdbjava</groupId>
+          <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
+          <version>0.9.24-2-SNAPSHOT</version>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <configuration>
+              <usedDependencies>
+                <usedDependency>org.lmdbjava:lmdbjava-native-linux-ppc64le</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
+                <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
+              </usedDependencies>
+              <ignoredDependencies>
+                <ignoredDependency>com.github.jnr:jffi</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>lmdbjava-shade</id>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>org.lmdbjava:lmdbjava-native-linux-ppc64le</include>
+                      <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
+                      <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
+                      <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,18 @@
     </dependency>
     <dependency>
       <groupId>org.lmdbjava</groupId>
+      <artifactId>lmdbjava-native-linux-aarch64</artifactId>
+      <version>0.9.24-2-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.lmdbjava</groupId>
+      <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
+      <version>0.9.24-2-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.lmdbjava</groupId>
       <artifactId>lmdbjava-native-linux-x86_64</artifactId>
       <version>0.9.24-1</version>
       <optional>true</optional>
@@ -112,6 +124,8 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-ppc64le</usedDependency>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
@@ -142,6 +156,8 @@
             <configuration>
               <artifactSet>
                 <includes>
+                  <include>org.lmdbjava:lmdbjava-native-linux-ppc64le</include>
+                  <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -102,8 +102,12 @@ final class Library {
     final String libToLoad;
 
     final String arch = getProperty("os.arch");
-    final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
+    final boolean x64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
+    final boolean aarch64 = "aarch64".equals(arch);
+    final boolean ppc64le = "ppc64le".equals(arch);
+
+    // final boolean arch64 = x64 || aarch64 || ppc64le;
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -112,11 +116,15 @@ final class Library {
 
     if (SHOULD_USE_LIB) {
       libToLoad = getProperty(LMDB_NATIVE_LIB_PROP);
-    } else if (SHOULD_EXTRACT && arch64 && linux) {
+    } else if (SHOULD_EXTRACT && aarch64 && linux) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
+    } else if (SHOULD_EXTRACT && ppc64le && linux) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-ppc64le.so");
+    } else if (SHOULD_EXTRACT && x64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
-    } else if (SHOULD_EXTRACT && arch64 && osx) {
+    } else if (SHOULD_EXTRACT && x64 && osx) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
-    } else if (SHOULD_EXTRACT && arch64 && windows) {
+    } else if (SHOULD_EXTRACT && x64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
     } else {
       libToLoad = LIB_NAME;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -29,6 +29,7 @@ import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static jnr.ffi.LibraryLoader.create;
 import static jnr.ffi.Runtime.getRuntime;
+import static org.lmdbjava.Env.Builder.PAGE_SIZE;
 
 import java.io.File;
 import java.io.IOException;
@@ -153,7 +154,7 @@ final class Library {
            OutputStream out = Files.newOutputStream(file.toPath())) {
         requireNonNull(in, "Classpath resource not found");
         int bytes;
-        final byte[] buffer = new byte[4_096];
+        final byte[] buffer = new byte[PAGE_SIZE];
         while (-1 != (bytes = in.read(buffer))) {
           out.write(buffer, 0, bytes);
         }

--- a/src/test/java/org/lmdbjava/CursorIterableTest.java
+++ b/src/test/java/org/lmdbjava/CursorIterableTest.java
@@ -125,7 +125,14 @@ public final class CursorIterableTest {
   public void before() throws IOException {
     final File path = tmp.newFile();
     env = create()
-        .setMapSize(KIBIBYTES.toBytes(100))
+        // 100 KB triggers Environment mapsize reached (-30792) on Txn.commit(Txn.java:110)
+        // on ppc64le and aarch64 systems with 65536 b big OS pages, i.e. 32768 b LMDB DB pages.
+        // 289 KB is just enough to hold the data without triggering the error.
+        // On a system with 4096 b OS pages, it translates to:
+        //   Asked for : 295936 bytes, got 299008, which is 73 DB pages.
+        // On a system with 65536 n OS pages, it translates to:
+        //   Asked for : 295936 bytes, got 327680, which is 10 DB pages.
+        .setMapSize(KIBIBYTES.toBytes(289))
         .setMaxReaders(1)
         .setMaxDbs(1)
         .open(path, POSIX_MODE, MDB_NOSUBDIR);

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -44,6 +44,7 @@ import static org.lmdbjava.ByteBufferProxy.PROXY_OPTIMAL;
 import static org.lmdbjava.DbiFlags.MDB_CREATE;
 import static org.lmdbjava.DbiFlags.MDB_DUPSORT;
 import static org.lmdbjava.DbiFlags.MDB_REVERSEKEY;
+import static org.lmdbjava.Env.Builder.PAGE_SIZE;
 import static org.lmdbjava.Env.create;
 import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
 import static org.lmdbjava.GetOp.MDB_SET_KEY;
@@ -457,7 +458,7 @@ public final class DbiTest {
     assertThat(stat.entries, is(3L));
     assertThat(stat.leafPages, is(1L));
     assertThat(stat.overflowPages, is(0L));
-    assertThat(stat.pageSize, is(4_096));
+    assertThat(stat.pageSize, is(PAGE_SIZE));
   }
 
   @Test(expected = MapFullException.class)

--- a/src/test/java/org/lmdbjava/TxnTest.java
+++ b/src/test/java/org/lmdbjava/TxnTest.java
@@ -84,7 +84,10 @@ public final class TxnTest {
   public void before() throws IOException {
     path = tmp.newFile();
     env = create()
-        .setMapSize(KIBIBYTES.toBytes(100))
+        // 100 was enough on systems with OS and DB pages of 4096 b.
+        // For systems with OS pages 65536 b big, i.e. 32768 b DB pages,
+        // 353 KB is the minimum for this test.
+        .setMapSize(KIBIBYTES.toBytes(353))
         .setMaxReaders(1)
         .setMaxDbs(2)
         .open(path, POSIX_MODE, MDB_NOSUBDIR);


### PR DESCRIPTION
Hello,

This PR surpasses #161. 
This PR depends on https://github.com/lmdbjava/native/pull/9
Notable changes:

 * PAGE_SIZE env and sys property configurable at runtime
 * allocations aligned to whole pages
 * size of DBs chnages according to what is needed when big pages are in use

Notable documentation these changes are based on:

     *    https://github.com/LMDB/lmdb/blob/LMDB_0.9.24/libraries/liblmdb/mdb.c#L498:L514
     *    https://github.com/LMDB/lmdb/blob/LMDB_0.9.24/libraries/liblmdb/lmdb.h#L813:L845

## How it was tested

```bash
git clone https://github.com/Karm/native.git
pushd native
git checkout  secondaryArches
git clone https://github.com/LMDB/lmdb.git
pushd lmdb
git checkout LMDB_0.9.24
popd
mvn clean install
popd
git clone https://github.com/Karm/lmdbjava.git 
pushd lmdbjava
git checkout secondaryArches
export PAGE_SIZE=$(getconf PAGESIZE)
mvn clean install
```

 ### RHEL 8 aarch64, 4 CPUs, 6G RAM
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.lmdbjava.KeyRangeTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.14 s - in org.lmdbjava.KeyRangeTest
[INFO] Running org.lmdbjava.CursorParamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.002 s - in org.lmdbjava.CursorParamTest
[INFO] Running org.lmdbjava.TxnTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 s - in org.lmdbjava.TxnTest
[INFO] Running org.lmdbjava.ResultCodeMapperTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in org.lmdbjava.ResultCodeMapperTest
[INFO] Running org.lmdbjava.LibraryTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in org.lmdbjava.LibraryTest
[INFO] Running org.lmdbjava.MaskedFlagTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.lmdbjava.MaskedFlagTest
[INFO] Running org.lmdbjava.DbiTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.873 s - in org.lmdbjava.DbiTest
[INFO] Running org.lmdbjava.CursorIterableTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.152 s - in org.lmdbjava.CursorIterableTest
[INFO] Running org.lmdbjava.MetaTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.lmdbjava.MetaTest
[INFO] Running org.lmdbjava.EnvTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.494 s - in org.lmdbjava.EnvTest
[INFO] Running org.lmdbjava.ComparatorTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s - in org.lmdbjava.ComparatorTest
[INFO] Running org.lmdbjava.VerifierTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.029 s - in org.lmdbjava.VerifierTest
[INFO] Running org.lmdbjava.CursorTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.06 s - in org.lmdbjava.CursorTest
[INFO] Running org.lmdbjava.ByteBufferProxyTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.lmdbjava.ByteBufferProxyTest
[INFO] Running org.lmdbjava.TutorialTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.118 s - in org.lmdbjava.TutorialTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 187, Failures: 0, Errors: 0, Skipped: 0
```

 ### RHEL 8 ppc64le, 50 CPUs, 252G RAM
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.lmdbjava.KeyRangeTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.209 s - in org.lmdbjava.KeyRangeTest
[INFO] Running org.lmdbjava.CursorParamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.275 s - in org.lmdbjava.CursorParamTest
[INFO] Running org.lmdbjava.TxnTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.331 s - in org.lmdbjava.TxnTest
[INFO] Running org.lmdbjava.ResultCodeMapperTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in org.lmdbjava.ResultCodeMapperTest
[INFO] Running org.lmdbjava.LibraryTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.lmdbjava.LibraryTest
[INFO] Running org.lmdbjava.MaskedFlagTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.lmdbjava.MaskedFlagTest
[INFO] Running org.lmdbjava.DbiTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 926.308 s - in org.lmdbjava.DbiTest
[INFO] Running org.lmdbjava.CursorIterableTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.52 s - in org.lmdbjava.CursorIterableTest
[INFO] Running org.lmdbjava.MetaTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.lmdbjava.MetaTest
[INFO] Running org.lmdbjava.EnvTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 132.677 s - in org.lmdbjava.EnvTest
[INFO] Running org.lmdbjava.ComparatorTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.lmdbjava.ComparatorTest
[INFO] Running org.lmdbjava.VerifierTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.294 s - in org.lmdbjava.VerifierTest
[INFO] Running org.lmdbjava.CursorTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.511 s - in org.lmdbjava.CursorTest
[INFO] Running org.lmdbjava.ByteBufferProxyTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in org.lmdbjava.ByteBufferProxyTest
[INFO] Running org.lmdbjava.TutorialTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.649 s - in org.lmdbjava.TutorialTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 187, Failures: 0, Errors: 0, Skipped: 0
```

 ### Fedora, amd64, 8 CPUs, 32G RAM  
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.lmdbjava.ResultCodeMapperTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s - in org.lmdbjava.ResultCodeMapperTest
[INFO] Running org.lmdbjava.TxnTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.463 s - in org.lmdbjava.TxnTest
[INFO] Running org.lmdbjava.LibraryTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.lmdbjava.LibraryTest
[INFO] Running org.lmdbjava.MetaTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in org.lmdbjava.MetaTest
[INFO] Running org.lmdbjava.EnvTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.129 s - in org.lmdbjava.EnvTest
[INFO] Running org.lmdbjava.CursorIterableTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s - in org.lmdbjava.CursorIterableTest
[INFO] Running org.lmdbjava.VerifierTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.002 s - in org.lmdbjava.VerifierTest
[INFO] Running org.lmdbjava.MaskedFlagTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.lmdbjava.MaskedFlagTest
[INFO] Running org.lmdbjava.TutorialTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.026 s - in org.lmdbjava.TutorialTest
[INFO] Running org.lmdbjava.KeyRangeTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in org.lmdbjava.KeyRangeTest
[INFO] Running org.lmdbjava.CursorParamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.219 s - in org.lmdbjava.CursorParamTest
[INFO] Running org.lmdbjava.ComparatorTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in org.lmdbjava.ComparatorTest
[INFO] Running org.lmdbjava.ByteBufferProxyTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in org.lmdbjava.ByteBufferProxyTest
[INFO] Running org.lmdbjava.CursorTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in org.lmdbjava.CursorTest
[INFO] Running org.lmdbjava.DbiTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.768 s - in org.lmdbjava.DbiTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 187, Failures: 0, Errors: 0, Skipped: 0
```

## Note about ppc64le
As you can see, Dbi test takes a very long time on the, ironically, most powerful ppc64le box, see:
```
[INFO] Running org.lmdbjava.DbiTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 926.308 s - in org.lmdbjava.DbiTest
```
I do not know why it takes so much time, but it happened more or less in the same way all three times I tried.
