### PR TITLE
fix lmdb link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # LMDB for Java
 
-[LMDB](http://symas.com/mdb/) offers:
+[LMDB](http://symas.com/lmdb/) offers:
 
 * Transactions (full ACID semantics)
 * Ordered keys (enabling very fast cursor-based iteration)


### PR DESCRIPTION
http://symas.com/mdb/ vs http://symas.com/lmdb/
former gives a "page not found", latter is correct link