### PR TITLE
Define manifest attribute Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.lmdbjava</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
       </plugin>
       <plugin>


### PR DESCRIPTION
This change defines the manifest attribute `Automatic-Module-Name`, transforming the JAR into an automatic module with module name `org.lmdbjava`. This should be enough for other Java modules to be able to reference this. I have verified that this is the case by installing it to a local repository and referencing it from my own projects.

Please note that doing this has no impact on non modular applications, which will simply ignore the attribute, both on older and newer JDKs. This change is an easy first step towards module support.