### PR TITLE
Add support for Linux and Mac ARM platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <configuration>
           <usedDependencies>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
-            <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-arm64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-arm64</usedDependency>
@@ -148,7 +148,7 @@
               <artifactSet>
                 <includes>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
-                  <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
+                  <include>org.lmdbjava:lmdbjava-native-linux-arm64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-arm64</include>

--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,10 @@
         <configuration>
           <usedDependencies>
             <usedDependency>org.lmdbjava:lmdbjava-native-linux-x86_64</usedDependency>
+            <usedDependency>org.lmdbjava:lmdbjava-native-linux-aarch64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-windows-x86_64</usedDependency>
             <usedDependency>org.lmdbjava:lmdbjava-native-osx-x86_64</usedDependency>
+            <usedDependency>org.lmdbjava:lmdbjava-native-osx-arm64</usedDependency>
           </usedDependencies>
           <ignoredDependencies>
             <ignoredDependency>com.github.jnr:jffi</ignoredDependency>
@@ -146,8 +148,10 @@
               <artifactSet>
                 <includes>
                   <include>org.lmdbjava:lmdbjava-native-linux-x86_64</include>
+                  <include>org.lmdbjava:lmdbjava-native-linux-aarch64</include>
                   <include>org.lmdbjava:lmdbjava-native-windows-x86_64</include>
                   <include>org.lmdbjava:lmdbjava-native-osx-x86_64</include>
+                  <include>org.lmdbjava:lmdbjava-native-osx-arm64</include>
                 </includes>
               </artifactSet>
             </configuration>

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -102,8 +102,9 @@ final class Library {
     final String libToLoad;
 
     final String arch = getProperty("os.arch");
-    final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
+    final boolean x64 = "x64".equals(arch) || "amd64".equals(arch)
                                || "x86_64".equals(arch);
+    final boolean arm64 = "arm64".equals(arch) || "aarch64".equals(arch);
 
     final String os = getProperty("os.name");
     final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
@@ -112,11 +113,15 @@ final class Library {
 
     if (SHOULD_USE_LIB) {
       libToLoad = getProperty(LMDB_NATIVE_LIB_PROP);
-    } else if (SHOULD_EXTRACT && arch64 && linux) {
+    } else if (SHOULD_EXTRACT && x64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
-    } else if (SHOULD_EXTRACT && arch64 && osx) {
+    } else if (SHOULD_EXTRACT && arm64 && linux) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
+    } else if (SHOULD_EXTRACT && x64 && osx) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
-    } else if (SHOULD_EXTRACT && arch64 && windows) {
+    } else if (SHOULD_EXTRACT && arm64 && osx) {
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-arm64.dylib");
+    } else if (SHOULD_EXTRACT && x64 && windows) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-windows-x86_64.dll");
     } else {
       libToLoad = LIB_NAME;

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -116,7 +116,7 @@ final class Library {
     } else if (SHOULD_EXTRACT && x64 && linux) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-x86_64.so");
     } else if (SHOULD_EXTRACT && arm64 && linux) {
-      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-aarch64.so");
+      libToLoad = extract("org/lmdbjava/lmdbjava-native-linux-arm64.so");
     } else if (SHOULD_EXTRACT && x64 && osx) {
       libToLoad = extract("org/lmdbjava/lmdbjava-native-osx-x86_64.dylib");
     } else if (SHOULD_EXTRACT && arm64 && osx) {


### PR DESCRIPTION
This commit is the counterpart change (and depends on) [this PR](https://github.com/lmdbjava/native/pull/13) in the native repo. It adds support for two additional versions of the underlying LMDB library, which are cross-compiled to add support for Linux and Mac ARM64 platforms.