### PR TITLE
Fix build on aarch64 (e.g. Apple Silicon)

### DIFF
--- a/src/test/java/org/lmdbjava/CursorIterableTest.java
+++ b/src/test/java/org/lmdbjava/CursorIterableTest.java
@@ -126,7 +126,7 @@ public final class CursorIterableTest {
   public void before() throws IOException {
     final File path = tmp.newFile();
     env = create()
-        .setMapSize(KIBIBYTES.toBytes(100))
+        .setMapSize(KIBIBYTES.toBytes(256))
         .setMaxReaders(1)
         .setMaxDbs(1)
         .open(path, POSIX_MODE, MDB_NOSUBDIR);

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -460,7 +460,7 @@ public final class DbiTest {
     assertThat(stat.entries, is(3L));
     assertThat(stat.leafPages, is(1L));
     assertThat(stat.overflowPages, is(0L));
-    assertThat(stat.pageSize, is(4_096));
+    assertThat(stat.pageSize % 4_096, is(0));
   }
 
   @Test(expected = MapFullException.class)

--- a/src/test/java/org/lmdbjava/EnvTest.java
+++ b/src/test/java/org/lmdbjava/EnvTest.java
@@ -394,7 +394,7 @@ public final class EnvTest {
       assertThat(stat.entries, is(0L));
       assertThat(stat.leafPages, is(0L));
       assertThat(stat.overflowPages, is(0L));
-      assertThat(stat.pageSize, is(4_096));
+      assertThat(stat.pageSize % 4_096, is(0));
       assertThat(stat.toString(), containsString("pageSize="));
     }
   }

--- a/src/test/java/org/lmdbjava/EnvTest.java
+++ b/src/test/java/org/lmdbjava/EnvTest.java
@@ -347,7 +347,7 @@ public final class EnvTest {
       db.put(bb(1), bb(42));
       boolean mapFullExThrown = false;
       try {
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 70; i++) {
           rnd.nextBytes(k);
           key.clear();
           key.put(k).flip();
@@ -359,7 +359,7 @@ public final class EnvTest {
       }
       assertThat(mapFullExThrown, is(true));
 
-      env.setMapSize(500_000);
+      env.setMapSize(KIBIBYTES.toBytes(512));
 
       try (Txn<ByteBuffer> roTxn = env.txnRead()) {
         assertThat(db.get(roTxn, bb(1)).getInt(), is(42));
@@ -367,7 +367,7 @@ public final class EnvTest {
 
       mapFullExThrown = false;
       try {
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 70; i++) {
           rnd.nextBytes(k);
           key.clear();
           key.put(k).flip();

--- a/src/test/java/org/lmdbjava/EnvTest.java
+++ b/src/test/java/org/lmdbjava/EnvTest.java
@@ -20,6 +20,7 @@
 
 package org.lmdbjava;
 
+import static com.jakewharton.byteunits.BinaryByteUnit.KIBIBYTES;
 import static com.jakewharton.byteunits.BinaryByteUnit.MEBIBYTES;
 import static java.nio.ByteBuffer.allocateDirect;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -338,7 +339,7 @@ public final class EnvTest {
     final Random rnd = new Random();
     try (Env<ByteBuffer> env = create()
         .setMaxReaders(1)
-        .setMapSize(50_000)
+        .setMapSize(KIBIBYTES.toBytes(256))
         .setMaxDbs(1)
         .open(path)) {
       final Dbi<ByteBuffer> db = env.openDbi(DB_1, MDB_CREATE);

--- a/src/test/java/org/lmdbjava/TxnTest.java
+++ b/src/test/java/org/lmdbjava/TxnTest.java
@@ -84,7 +84,7 @@ public final class TxnTest {
   public void before() throws IOException {
     path = tmp.newFile();
     env = create()
-        .setMapSize(KIBIBYTES.toBytes(100))
+        .setMapSize(KIBIBYTES.toBytes(256))
         .setMaxReaders(1)
         .setMaxDbs(2)
         .open(path, POSIX_MODE, MDB_NOSUBDIR);


### PR DESCRIPTION
This pull request adopts an approach in which it is the library client that must consider appropriate map sizes. This is because map size is determined by the use case, and by system architecture. The documentation for LMDB clearly states that map size must be a multiple of the OS virtual memory page size. For most architectures this remains 4KiB, but newer architectures such as aarch64 have used 16KiB or 64KiB. Apple Silicon uses 16KiB. 

As such, this pull request only changes tests so that the test suite passes on architectures with a larger page size than 4KiB. 

The alternative is to help clients by massaging requested map sizes into something a multiple of the current architecture's page size, but this might be brittle. I would think it a reasonable assumption that consumers of lmdbjava will understand the issues here [although on reflection, perhaps the javadoc should make this very clear]. LMDB itself makes no attempt to fix map size based on its knowledge of system architecture and page size, and I think it reasonable that lmdbjava adopts that approach.

On MacBook Pro M1:
```
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.lmdbjava.MetaTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.229 s - in org.lmdbjava.MetaTest
[INFO] Running org.lmdbjava.ResultCodeMapperTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 s - in org.lmdbjava.ResultCodeMapperTest
[INFO] Running org.lmdbjava.ByteBufferProxyTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.253 s - in org.lmdbjava.ByteBufferProxyTest
[INFO] Running org.lmdbjava.KeyRangeTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in org.lmdbjava.KeyRangeTest
[INFO] Running org.lmdbjava.ComparatorTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.283 s - in org.lmdbjava.ComparatorTest
[INFO] Running org.lmdbjava.TxnTest
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.277 s - in org.lmdbjava.TxnTest
[INFO] Running org.lmdbjava.CursorParamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.296 s - in org.lmdbjava.CursorParamTest
[INFO] Running org.lmdbjava.TargetNameTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in org.lmdbjava.TargetNameTest
[INFO] Running org.lmdbjava.MaskedFlagTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in org.lmdbjava.MaskedFlagTest
[INFO] Running org.lmdbjava.CursorTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.271 s - in org.lmdbjava.CursorTest
[INFO] Running org.lmdbjava.VerifierTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.274 s - in org.lmdbjava.VerifierTest
[INFO] Running org.lmdbjava.CursorIterableTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.278 s - in org.lmdbjava.CursorIterableTest
[INFO] Running org.lmdbjava.EnvTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.657 s - in org.lmdbjava.EnvTest
[INFO] Running org.lmdbjava.LibraryTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.25 s - in org.lmdbjava.LibraryTest
[INFO] Running org.lmdbjava.DbiTest
[INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.595 s - in org.lmdbjava.DbiTest
[INFO] Running org.lmdbjava.TutorialTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.268 s - in org.lmdbjava.TutorialTest
[INFO] Running org.lmdbjava.GarbageCollectionTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.881 s - in org.lmdbjava.GarbageCollectionTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 222, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.972 s
[INFO] Finished at: 2023-04-25T07:40:07+01:00
[INFO] ------------------------------------------------------------------------
```