### PR TITLE
Regression: Add DbiFlags#MDB_UNSIGNEDKEY to allow to compare byte array, ByteBuffer and DirectBuffer keys as unsigned like in versions prior to 0.9.0

### DIFF
--- a/src/main/java/org/lmdbjava/BufferProxy.java
+++ b/src/main/java/org/lmdbjava/BufferProxy.java
@@ -21,6 +21,10 @@
 package org.lmdbjava;
 
 import static java.lang.Long.BYTES;
+import static org.lmdbjava.DbiFlags.MDB_INTEGERKEY;
+import static org.lmdbjava.DbiFlags.MDB_UNSIGNEDKEY;
+import static org.lmdbjava.MaskedFlag.isSet;
+import static org.lmdbjava.MaskedFlag.mask;
 
 import java.util.Comparator;
 
@@ -72,8 +76,24 @@ public abstract class BufferProxy<T> {
    * @param flags for the database
    * @return a comparator that can be used (never null)
    */
-  protected abstract Comparator<T> getComparator(DbiFlags... flags);
+  protected Comparator<T> getComparator(DbiFlags... flags) {
+    final int intFlag = mask(flags);
 
+    return isSet(intFlag, MDB_INTEGERKEY) || isSet(intFlag, MDB_UNSIGNEDKEY) ? getUnsignedComparator() : getSignedComparator();
+  }
+
+  /**
+   * Get a suitable default {@link Comparator} to compare numeric key values as unsigned.
+   *
+   * @return a comparator that can be used (never null)
+   */
+  protected abstract Comparator<T> getUnsignedComparator();
+  /**
+   * Get a suitable default {@link Comparator} to compare numeric key values as signed.
+   *
+   * @return a comparator that can be used (never null)
+   */
+  protected abstract Comparator<T> getSignedComparator();
   /**
    * Deallocate a buffer that was previously provided by {@link #allocate()}.
    *

--- a/src/main/java/org/lmdbjava/ByteBufProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufProxy.java
@@ -20,16 +20,17 @@
 
 package org.lmdbjava;
 
-import static io.netty.buffer.PooledByteBufAllocator.DEFAULT;
-import static java.lang.Class.forName;
-import static org.lmdbjava.UnsafeAccess.UNSAFE;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import jnr.ffi.Pointer;
 
 import java.lang.reflect.Field;
 import java.util.Comparator;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-import jnr.ffi.Pointer;
+import static io.netty.buffer.PooledByteBufAllocator.DEFAULT;
+import static java.lang.Class.forName;
+import static java.util.Objects.requireNonNull;
+import static org.lmdbjava.UnsafeAccess.UNSAFE;
 
 /**
  * A buffer proxy backed by Netty's {@link ByteBuf}.
@@ -51,6 +52,12 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
   private static final String FIELD_NAME_ADDRESS = "memoryAddress";
   private static final String FIELD_NAME_LENGTH = "length";
   private static final String NAME = "io.netty.buffer.PooledUnsafeDirectByteBuf";
+  private static final Comparator<ByteBuf> comparator = (o1, o2) -> {
+    requireNonNull(o1);
+    requireNonNull(o2);
+
+    return o1.compareTo(o2);
+  };
   private final long lengthOffset;
   private final long addressOffset;
   
@@ -107,13 +114,14 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
     throw new IllegalStateException("Netty buffer must be " + NAME);
   }
 
-  protected int compare(final ByteBuf o1, final ByteBuf o2) {
-    return o1.compareTo(o2);
+  @Override
+  protected Comparator<ByteBuf> getSignedComparator() {
+    return comparator;
   }
 
   @Override
-  protected Comparator<ByteBuf> getComparator(final DbiFlags... flags) {
-    return this::compare;
+  protected Comparator<ByteBuf> getUnsignedComparator() {
+    return comparator;
   }
 
   @Override

--- a/src/main/java/org/lmdbjava/ByteBufferProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufferProxy.java
@@ -27,6 +27,7 @@ import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
 import static org.lmdbjava.DbiFlags.MDB_INTEGERKEY;
+import static org.lmdbjava.DbiFlags.MDB_UNSIGNEDKEY;
 import static org.lmdbjava.Env.SHOULD_CHECK;
 import static org.lmdbjava.MaskedFlag.isSet;
 import static org.lmdbjava.MaskedFlag.mask;
@@ -111,6 +112,14 @@ public final class ByteBufferProxy {
     protected static final String FIELD_NAME_ADDRESS = "address";
     protected static final String FIELD_NAME_CAPACITY = "capacity";
 
+    private static final Comparator<ByteBuffer> signedComparator = (o1, o2) -> {
+      requireNonNull(o1);
+      requireNonNull(o2);
+
+      return o1.compareTo(o2);
+    };
+    private static final Comparator<ByteBuffer> unsignedComparator = AbstractByteBufferProxy::compareBuff;
+
     /**
      * A thread-safe pool for a given length. If the buffer found is valid (ie
      * not of a negative length) then that buffer is used. If no valid buffer is
@@ -193,22 +202,13 @@ public final class ByteBufferProxy {
     }
 
     @Override
-    protected Comparator<ByteBuffer> getComparator(final DbiFlags... flags) {
-      final int flagInt = mask(flags);
-      if (isSet(flagInt, MDB_INTEGERKEY)) {
-        return this::compareCustom;
-      }
-      return this::compareDefault;
+    protected Comparator<ByteBuffer> getSignedComparator() {
+      return signedComparator;
     }
 
-    protected final int compareDefault(final ByteBuffer o1,
-                                       final ByteBuffer o2) {
-      return o1.compareTo(o2);
-    }
-
-    protected final int compareCustom(final ByteBuffer o1,
-                                      final ByteBuffer o2) {
-      return compareBuff(o1, o2);
+    @Override
+    protected Comparator<ByteBuffer> getUnsignedComparator() {
+      return unsignedComparator;
     }
 
     @Override

--- a/src/main/java/org/lmdbjava/Cursor.java
+++ b/src/main/java/org/lmdbjava/Cursor.java
@@ -40,6 +40,8 @@ import static org.lmdbjava.SeekOp.MDB_PREV;
 import jnr.ffi.Pointer;
 import jnr.ffi.byref.NativeLongByReference;
 
+import java.util.Arrays;
+
 /**
  * A cursor handle.
  *
@@ -120,7 +122,7 @@ public final class Cursor<T> implements AutoCloseable {
       txn.checkReady();
       txn.checkWritesAllowed();
     }
-    final int flags = mask(f);
+    final int flags = mask(true, f);
     checkRc(LIB.mdb_cursor_del(ptrCursor, flags));
   }
 
@@ -256,7 +258,7 @@ public final class Cursor<T> implements AutoCloseable {
     }
     kv.keyIn(key);
     kv.valIn(val);
-    final int mask = mask(op);
+    final int mask = mask(true, op);
     final int rc = LIB.mdb_cursor_put(ptrCursor, kv.pointerKey(),
                                       kv.pointerVal(), mask);
     if (rc == MDB_KEYEXIST) {
@@ -299,7 +301,7 @@ public final class Cursor<T> implements AutoCloseable {
       txn.checkReady();
       txn.checkWritesAllowed();
     }
-    final int mask = mask(op);
+    final int mask = mask(true, op);
     if (SHOULD_CHECK && !isSet(mask, MDB_MULTIPLE)) {
       throw new IllegalArgumentException("Must set " + MDB_MULTIPLE + " flag");
     }
@@ -364,7 +366,7 @@ public final class Cursor<T> implements AutoCloseable {
     }
     kv.keyIn(key);
     kv.valIn(size);
-    final int flags = mask(op) | MDB_RESERVE.getMask();
+    final int flags = mask(true, op) | MDB_RESERVE.getMask();
     checkRc(LIB.mdb_cursor_put(ptrCursor, kv.pointerKey(), kv.pointerVal(),
                                flags));
     kv.valOut();

--- a/src/main/java/org/lmdbjava/DbiFlags.java
+++ b/src/main/java/org/lmdbjava/DbiFlags.java
@@ -69,6 +69,15 @@ public enum DbiFlags implements MaskedFlag {
    */
   MDB_INTEGERDUP(0x20),
   /**
+   * Compare the <b>numeric</b> keys in native byte order and as unsigned.
+   *
+   * <p>
+   * This option is applied only to {@link java.nio.ByteBuffer}, {@link org.agrona.DirectBuffer} and byte array keys.
+   * {@link io.netty.buffer.ByteBuf} keys are always compared in native byte order and as unsigned.
+   * </p>
+   */
+  MDB_UNSIGNEDKEY(0x30, false),
+  /**
    * With {@link #MDB_DUPSORT}, use reverse string dups.
    *
    * <p>
@@ -86,9 +95,15 @@ public enum DbiFlags implements MaskedFlag {
   MDB_CREATE(0x4_0000);
 
   private final int mask;
+  private final boolean propagatedToLmdb;
+
+  DbiFlags(final int mask, final boolean propagatedToLmdb) {
+    this.mask = mask;
+    this.propagatedToLmdb = propagatedToLmdb;
+  }
 
   DbiFlags(final int mask) {
-    this.mask = mask;
+    this(mask, true);
   }
 
   @Override
@@ -96,4 +111,8 @@ public enum DbiFlags implements MaskedFlag {
     return mask;
   }
 
+  @Override
+  public boolean isPropagatedToLmdb() {
+    return propagatedToLmdb;
+  }
 }

--- a/src/main/java/org/lmdbjava/Txn.java
+++ b/src/main/java/org/lmdbjava/Txn.java
@@ -20,6 +20,8 @@
 
 package org.lmdbjava;
 
+import jnr.ffi.Pointer;
+
 import static jnr.ffi.Memory.allocateDirect;
 import static jnr.ffi.NativeType.ADDRESS;
 import static org.lmdbjava.Env.SHOULD_CHECK;
@@ -33,8 +35,6 @@ import static org.lmdbjava.Txn.State.READY;
 import static org.lmdbjava.Txn.State.RELEASED;
 import static org.lmdbjava.Txn.State.RESET;
 import static org.lmdbjava.TxnFlags.MDB_RDONLY_TXN;
-
-import jnr.ffi.Pointer;
 
 /**
  * LMDB transaction.
@@ -55,7 +55,7 @@ public final class Txn<T> implements AutoCloseable {
       final TxnFlags... flags) {
     this.proxy = proxy;
     this.keyVal = proxy.keyVal();
-    final int flagsMask = mask(flags);
+    final int flagsMask = mask(true, flags);
     this.readOnly = isSet(flagsMask, MDB_RDONLY_TXN);
     if (env.isReadOnly() && !this.readOnly) {
       throw new EnvIsReadOnly();


### PR DESCRIPTION
Fixes https://github.com/lmdbjava/lmdbjava/issues/228 and https://github.com/lmdbjava/lmdbjava/issues/230.

I was not able to run the tests locally on Windows (I'm getting a `NoClassDefFoundError` kind of everywhere), so I hope I didn't break any.