### PR TITLE
Uplift lmdb from 0.9.29 to 0.9.31

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,7 +73,7 @@ jobs:
         run: mvn -B test -Dtest=VerifierTest -DverificationSeconds=10
 
       - name: Upload Surefire reports on test failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: surefire-test-log
@@ -116,7 +116,7 @@ jobs:
         MAVEN_CENTRAL_TOKEN: ${{ secrets.nexus_password }}
 
     - name: Debug settings.xml
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: settings.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
       run: mvn -B verify -DgcRecordWrites=1000
 
     - name: Store built native libraries for later jobs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: native-libraries
         path: |
@@ -64,7 +64,7 @@ jobs:
           cache: maven
 
       - name: Fetch built native libraries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: native-libraries
           path: src/main/resources/org/lmdbjava

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 rm -rf lmdb
-git clone --depth 1 --branch LMDB_0.9.29 https://github.com/LMDB/lmdb.git
+git clone --depth 1 --branch LMDB_0.9.31 https://github.com/LMDB/lmdb.git
 pushd lmdb/libraries/liblmdb
 trap popd SIGINT
 


### PR DESCRIPTION
Uplifting the LMDB lib to bring in bug fixes.


From https://github.com/openldap/openldap/blob/master/libraries/liblmdb/CHANGES
```
LMDB 0.9.33 Release (2024/05/21)
	ITS#9037 mdb_page_search: fix error code when DBI record is missing
	ITS#10198 For win32, stop passing ignored parameter
	ITS#10212 Fix meta page usage by read only tools

LMDB 0.9.32 Release (2024/01/29)
	ITS#9378 - Add ability to replay log and replay log tool
	ITS#10095 - partial revert of ITS#9278. The patch was incorrect and introduced numerous race conditions.
	ITS#10125 - mdb_load: fix cursor reinit in Append mode
	ITS#10137 - Allow users to define MDB_IDL_LOGN

LMDB 0.9.31 Release (2023/07/10)
	ITS#8447 - Fix cursor_put(MDB_CURRENT) on DUPSORT DB with different sized data

LMDB 0.9.30 Release (2023/02/08)
	ITS#9806 - LMDB page_split: key threshold depends on page size
	ITS#9916 - avoid gcc optimization bug on sparc64 linux
	ITS#9919 - Mark infrequently used functions as cold
	ITS#9723 - clear C_EOF on cursor with MDB_FIRST_DUP
	ITS#9030 - Use sys/cachectl.h rather than asm/cachectl.h on mips
```