### PR TITLE
gh-249 Remove MDB_UNSIGNEDKEY, let CursorIterable call mdb_cmp

### DIFF
--- a/src/main/java/org/lmdbjava/BufferProxy.java
+++ b/src/main/java/org/lmdbjava/BufferProxy.java
@@ -16,10 +16,6 @@
 package org.lmdbjava;
 
 import static java.lang.Long.BYTES;
-import static org.lmdbjava.DbiFlags.MDB_INTEGERKEY;
-import static org.lmdbjava.DbiFlags.MDB_UNSIGNEDKEY;
-import static org.lmdbjava.MaskedFlag.isSet;
-import static org.lmdbjava.MaskedFlag.mask;
 
 import java.util.Comparator;
 import jnr.ffi.Pointer;
@@ -71,35 +67,24 @@ public abstract class BufferProxy<T> {
   protected abstract byte[] getBytes(T buffer);
 
   /**
-   * Get a suitable default {@link Comparator} given the provided flags.
-   *
-   * <p>The provided comparator must strictly match the lexicographical order of keys in the native
-   * LMDB database.
-   *
-   * @param flags for the database
-   * @return a comparator that can be used (never null)
-   */
-  protected Comparator<T> getComparator(DbiFlags... flags) {
-    final int intFlag = mask(flags);
-
-    return isSet(intFlag, MDB_INTEGERKEY) || isSet(intFlag, MDB_UNSIGNEDKEY)
-        ? getUnsignedComparator()
-        : getSignedComparator();
-  }
-
-  /**
    * Get a suitable default {@link Comparator} to compare numeric key values as signed.
    *
+   * <p>
+   * Note: LMDB's default comparator is unsigned so if this is used only for the {@link CursorIterable}
+   * start/stop key comparisons then its behaviour will differ from the iteration order. Use
+   * with caution.
+   * </p>
+   *
    * @return a comparator that can be used (never null)
    */
-  protected abstract Comparator<T> getSignedComparator();
+  public abstract Comparator<T> getSignedComparator();
 
   /**
    * Get a suitable default {@link Comparator} to compare numeric key values as unsigned.
    *
    * @return a comparator that can be used (never null)
    */
-  protected abstract Comparator<T> getUnsignedComparator();
+  public abstract Comparator<T> getUnsignedComparator();
 
   /**
    * Called when the <code>MDB_val</code> should be set to reflect the passed buffer. This buffer
@@ -139,5 +124,14 @@ public abstract class BufferProxy<T> {
    */
   final KeyVal<T> keyVal() {
     return new KeyVal<>(this);
+  }
+
+  /**
+   * Create a new {@link Key} to hold pointers for this buffer proxy.
+   *
+   * @return a non-null key holder
+   */
+  final Key<T> key() {
+    return new Key<>(this);
   }
 }

--- a/src/main/java/org/lmdbjava/ByteArrayProxy.java
+++ b/src/main/java/org/lmdbjava/ByteArrayProxy.java
@@ -104,12 +104,12 @@ public final class ByteArrayProxy extends BufferProxy<byte[]> {
   }
 
   @Override
-  protected Comparator<byte[]> getSignedComparator() {
+  public Comparator<byte[]> getSignedComparator() {
     return signedComparator;
   }
 
   @Override
-  protected Comparator<byte[]> getUnsignedComparator() {
+  public Comparator<byte[]> getUnsignedComparator() {
     return unsignedComparator;
   }
 

--- a/src/main/java/org/lmdbjava/ByteBufProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufProxy.java
@@ -114,12 +114,12 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
   }
 
   @Override
-  protected Comparator<ByteBuf> getSignedComparator() {
+  public Comparator<ByteBuf> getSignedComparator() {
     return comparator;
   }
 
   @Override
-  protected Comparator<ByteBuf> getUnsignedComparator() {
+  public Comparator<ByteBuf> getUnsignedComparator() {
     return comparator;
   }
 

--- a/src/main/java/org/lmdbjava/ByteBufferProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufferProxy.java
@@ -182,12 +182,12 @@ public final class ByteBufferProxy {
     }
 
     @Override
-    protected Comparator<ByteBuffer> getSignedComparator() {
+    public Comparator<ByteBuffer> getSignedComparator() {
       return signedComparator;
     }
 
     @Override
-    protected Comparator<ByteBuffer> getUnsignedComparator() {
+    public Comparator<ByteBuffer> getUnsignedComparator() {
       return unsignedComparator;
     }
 

--- a/src/main/java/org/lmdbjava/Cursor.java
+++ b/src/main/java/org/lmdbjava/Cursor.java
@@ -196,6 +196,10 @@ public final class Cursor<T> implements AutoCloseable {
     return kv.key();
   }
 
+  KeyVal<T> keyVal() {
+    return kv;
+  }
+
   /**
    * Position at last key/data item.
    *

--- a/src/main/java/org/lmdbjava/CursorIterable.java
+++ b/src/main/java/org/lmdbjava/CursorIterable.java
@@ -21,10 +21,14 @@ import static org.lmdbjava.CursorIterable.State.REQUIRES_ITERATOR_OP;
 import static org.lmdbjava.CursorIterable.State.REQUIRES_NEXT_OP;
 import static org.lmdbjava.CursorIterable.State.TERMINATED;
 import static org.lmdbjava.GetOp.MDB_SET_RANGE;
+import static org.lmdbjava.Library.LIB;
 
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Supplier;
+import jnr.ffi.Pointer;
 import org.lmdbjava.KeyRangeType.CursorOp;
 import org.lmdbjava.KeyRangeType.IteratorOp;
 
@@ -38,185 +42,266 @@ import org.lmdbjava.KeyRangeType.IteratorOp;
  */
 public final class CursorIterable<T> implements Iterable<CursorIterable.KeyVal<T>>, AutoCloseable {
 
-  private final Comparator<T> comparator;
-  private final Cursor<T> cursor;
-  private final KeyVal<T> entry;
-  private boolean iteratorReturned;
-  private final KeyRange<T> range;
-  private State state = REQUIRES_INITIAL_OP;
+    //  private final Comparator<T> comparator;
+    private final RangeComparator rangeComparator;
+    private final Cursor<T> cursor;
+    private final Dbi<T> dbi;
+    private final KeyVal<T> entry;
+    private boolean iteratorReturned;
+    private final KeyRange<T> range;
+    private State state = REQUIRES_INITIAL_OP;
+    private final Key<T> startKey;
+    private final Key<T> stopKey;
 
-  CursorIterable(
-      final Txn<T> txn, final Dbi<T> dbi, final KeyRange<T> range, final Comparator<T> comparator) {
-    this.cursor = dbi.openCursor(txn);
-    this.range = range;
-    this.comparator = comparator;
-    this.entry = new KeyVal<>();
-  }
+    CursorIterable(
+            final Txn<T> txn,
+            final Dbi<T> dbi,
+            final KeyRange<T> range,
+            final Comparator<T> comparator,
+            final BufferProxy<T> proxy) {
+        this.cursor = dbi.openCursor(txn);
+        this.dbi = dbi;
+        this.range = range;
+        this.entry = new KeyVal<>();
 
-  @Override
-  public void close() {
-    cursor.close();
-  }
-
-  /**
-   * Obtain an iterator.
-   *
-   * <p>As iteration of the returned iterator will cause movement of the underlying LMDB cursor, an
-   * {@link IllegalStateException} is thrown if an attempt is made to obtain the iterator more than
-   * once. For advanced cursor control (such as being able to iterate over the same data multiple
-   * times etc) please instead refer to {@link Dbi#openCursor(org.lmdbjava.Txn)}.
-   *
-   * @return an iterator
-   */
-  @Override
-  public Iterator<KeyVal<T>> iterator() {
-    if (iteratorReturned) {
-      throw new IllegalStateException("Iterator can only be returned once");
-    }
-    iteratorReturned = true;
-
-    return new Iterator<KeyVal<T>>() {
-      @Override
-      public boolean hasNext() {
-        while (state != RELEASED && state != TERMINATED) {
-          update();
+        if (comparator != null) {
+            // User supplied java-side comparator so use that
+            this.rangeComparator = createJavaRangeComparator(range, comparator, entry::key);
+            this.startKey = null;
+            this.stopKey = null;
+        } else {
+            // No java-side comparator so call down to LMDB to do the comparison
+            this.rangeComparator = createLmdbDbiComparator(txn.pointer(), dbi.pointer());
+            // Allocate buffers for use with the start/stop keys if required.
+            // Saves us copying bytes on each comparison
+            this.startKey = createKey(range.getStart(), proxy);
+            this.stopKey = createKey(range.getStop(), proxy);
         }
-        return state == RELEASED;
-      }
+    }
 
-      @Override
-      public KeyVal<T> next() {
-        if (!hasNext()) {
-          throw new NoSuchElementException();
+    private Key<T> createKey(final T keyBuffer, final BufferProxy<T> proxy) {
+        if (keyBuffer != null) {
+            final Key<T> key = proxy.key();
+            key.keyIn(keyBuffer);
+            return key;
+        } else {
+            return null;
         }
-        state = REQUIRES_NEXT_OP;
-        return entry;
-      }
-
-      @Override
-      public void remove() {
-        cursor.delete();
-      }
-    };
-  }
-
-  private void executeCursorOp(final CursorOp op) {
-    final boolean found;
-    switch (op) {
-      case FIRST:
-        found = cursor.first();
-        break;
-      case LAST:
-        found = cursor.last();
-        break;
-      case NEXT:
-        found = cursor.next();
-        break;
-      case PREV:
-        found = cursor.prev();
-        break;
-      case GET_START_KEY:
-        found = cursor.get(range.getStart(), MDB_SET_RANGE);
-        break;
-      case GET_START_KEY_BACKWARD:
-        found = cursor.get(range.getStart(), MDB_SET_RANGE) || cursor.last();
-        break;
-      default:
-        throw new IllegalStateException("Unknown cursor operation");
     }
-    entry.setK(found ? cursor.key() : null);
-    entry.setV(found ? cursor.val() : null);
-  }
 
-  private void executeIteratorOp() {
-    final IteratorOp op =
-        range.getType().iteratorOp(range.getStart(), range.getStop(), entry.key(), comparator);
-    switch (op) {
-      case CALL_NEXT_OP:
-        executeCursorOp(range.getType().nextOp());
-        state = REQUIRES_ITERATOR_OP;
-        break;
-      case TERMINATE:
-        state = TERMINATED;
-        break;
-      case RELEASE:
-        state = RELEASED;
-        break;
-      default:
-        throw new IllegalStateException("Unknown operation");
-    }
-  }
+    static <T> RangeComparator createJavaRangeComparator(
+            final KeyRange<T> range,
+            final Comparator<T> comparator,
+            final Supplier<T> currentKeySupplier) {
+        final T start = range.getStart();
+        final T stop = range.getStop();
+        return new RangeComparator() {
+            @Override
+            public int compareToStartKey() {
+                return comparator.compare(currentKeySupplier.get(), start);
+            }
 
-  private void update() {
-    switch (state) {
-      case REQUIRES_INITIAL_OP:
-        executeCursorOp(range.getType().initialOp());
-        state = REQUIRES_ITERATOR_OP;
-        break;
-      case REQUIRES_NEXT_OP:
-        executeCursorOp(range.getType().nextOp());
-        state = REQUIRES_ITERATOR_OP;
-        break;
-      case REQUIRES_ITERATOR_OP:
-        executeIteratorOp();
-        break;
-      case TERMINATED:
-        break;
-      default:
-        throw new IllegalStateException("Unknown state");
-    }
-  }
-
-  /**
-   * Holder for a key and value pair.
-   *
-   * <p>The same holder instance will always be returned for a given iterator. The returned keys and
-   * values may change or point to different memory locations following changes in the iterator,
-   * cursor or transaction.
-   *
-   * @param <T> buffer type
-   */
-  public static final class KeyVal<T> {
-
-    private T k;
-    private T v;
-
-    /** Explicitly-defined default constructor to avoid warnings. */
-    public KeyVal() {}
-
-    /**
-     * The key.
-     *
-     * @return key
-     */
-    public T key() {
-      return k;
+            @Override
+            public int compareToStopKey() {
+                return comparator.compare(currentKeySupplier.get(), stop);
+            }
+        };
     }
 
     /**
-     * The value.
+     * Calls down to mdb_cmp to make use of the comparator that LMDB uses for insertion order.
      *
-     * @return value
+     * @param txnPointer The pointer to the transaction.
+     * @param dbiPointer The pointer to the Dbi so LMDB can use the comparator of the Dbi
      */
-    public T val() {
-      return v;
+    private RangeComparator createLmdbDbiComparator(
+            final Pointer txnPointer, final Pointer dbiPointer) {
+        Objects.requireNonNull(txnPointer);
+        Objects.requireNonNull(dbiPointer);
+        Objects.requireNonNull(cursor);
+
+        return new RangeComparator() {
+            @Override
+            public int compareToStartKey() {
+                return LIB.mdb_cmp(txnPointer, dbiPointer, cursor.keyVal().pointerKey(), startKey.pointerKey());
+            }
+
+            @Override
+            public int compareToStopKey() {
+                return LIB.mdb_cmp(txnPointer, dbiPointer, cursor.keyVal().pointerKey(), stopKey.pointerKey());
+            }
+        };
     }
 
-    void setK(final T key) {
-      this.k = key;
+    @Override
+    public void close() {
+        cursor.close();
     }
 
-    void setV(final T val) {
-      this.v = val;
-    }
-  }
+    /**
+     * Obtain an iterator.
+     *
+     * <p>As iteration of the returned iterator will cause movement of the underlying LMDB cursor, an
+     * {@link IllegalStateException} is thrown if an attempt is made to obtain the iterator more than
+     * once. For advanced cursor control (such as being able to iterate over the same data multiple
+     * times etc) please instead refer to {@link Dbi#openCursor(org.lmdbjava.Txn)}.
+     *
+     * @return an iterator
+     */
+    @Override
+    public Iterator<KeyVal<T>> iterator() {
+        if (iteratorReturned) {
+            throw new IllegalStateException("Iterator can only be returned once");
+        }
+        iteratorReturned = true;
 
-  /** Represents the internal {@link CursorIterable} state. */
-  enum State {
-    REQUIRES_INITIAL_OP,
-    REQUIRES_NEXT_OP,
-    REQUIRES_ITERATOR_OP,
-    RELEASED,
-    TERMINATED
-  }
+        return new Iterator<KeyVal<T>>() {
+            @Override
+            public boolean hasNext() {
+                while (state != RELEASED && state != TERMINATED) {
+                    update();
+                }
+                return state == RELEASED;
+            }
+
+            @Override
+            public KeyVal<T> next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                state = REQUIRES_NEXT_OP;
+                return entry;
+            }
+
+            @Override
+            public void remove() {
+                cursor.delete();
+            }
+        };
+    }
+
+    private void executeCursorOp(final CursorOp op) {
+        final boolean found;
+        switch (op) {
+            case FIRST:
+                found = cursor.first();
+                break;
+            case LAST:
+                found = cursor.last();
+                break;
+            case NEXT:
+                found = cursor.next();
+                break;
+            case PREV:
+                found = cursor.prev();
+                break;
+            case GET_START_KEY:
+                found = cursor.get(range.getStart(), MDB_SET_RANGE);
+                break;
+            case GET_START_KEY_BACKWARD:
+                found = cursor.get(range.getStart(), MDB_SET_RANGE) || cursor.last();
+                break;
+            default:
+                throw new IllegalStateException("Unknown cursor operation");
+        }
+        entry.setK(found ? cursor.key() : null);
+        entry.setV(found ? cursor.val() : null);
+    }
+
+    private void executeIteratorOp() {
+        final IteratorOp op =
+                range.getType().iteratorOp(range.getStart(), range.getStop(), entry.key(), rangeComparator);
+        switch (op) {
+            case CALL_NEXT_OP:
+                executeCursorOp(range.getType().nextOp());
+                state = REQUIRES_ITERATOR_OP;
+                break;
+            case TERMINATE:
+                state = TERMINATED;
+                break;
+            case RELEASE:
+                state = RELEASED;
+                break;
+            default:
+                throw new IllegalStateException("Unknown operation");
+        }
+    }
+
+    private void update() {
+        switch (state) {
+            case REQUIRES_INITIAL_OP:
+                executeCursorOp(range.getType().initialOp());
+                state = REQUIRES_ITERATOR_OP;
+                break;
+            case REQUIRES_NEXT_OP:
+                executeCursorOp(range.getType().nextOp());
+                state = REQUIRES_ITERATOR_OP;
+                break;
+            case REQUIRES_ITERATOR_OP:
+                executeIteratorOp();
+                break;
+            case TERMINATED:
+                break;
+            default:
+                throw new IllegalStateException("Unknown state");
+        }
+    }
+
+    /**
+     * Holder for a key and value pair.
+     *
+     * <p>The same holder instance will always be returned for a given iterator. The returned keys and
+     * values may change or point to different memory locations following changes in the iterator,
+     * cursor or transaction.
+     *
+     * @param <T> buffer type
+     */
+    public static final class KeyVal<T> {
+
+        private T k;
+        private T v;
+
+        /**
+         * Explicitly-defined default constructor to avoid warnings.
+         */
+        public KeyVal() {
+        }
+
+        /**
+         * The key.
+         *
+         * @return key
+         */
+        public T key() {
+            return k;
+        }
+
+        /**
+         * The value.
+         *
+         * @return value
+         */
+        public T val() {
+            return v;
+        }
+
+        void setK(final T key) {
+            this.k = key;
+        }
+
+        void setV(final T val) {
+            this.v = val;
+        }
+    }
+
+    /**
+     * Represents the internal {@link CursorIterable} state.
+     */
+    enum State {
+        REQUIRES_INITIAL_OP,
+        REQUIRES_NEXT_OP,
+        REQUIRES_ITERATOR_OP,
+        RELEASED,
+        TERMINATED
+    }
 }

--- a/src/main/java/org/lmdbjava/DbiFlags.java
+++ b/src/main/java/org/lmdbjava/DbiFlags.java
@@ -56,14 +56,6 @@ public enum DbiFlags implements MaskedFlag {
    */
   MDB_INTEGERDUP(0x20),
   /**
-   * Compare the <b>numeric</b> keys in native byte order and as unsigned.
-   *
-   * <p>This option is applied only to {@link java.nio.ByteBuffer}, {@link org.agrona.DirectBuffer}
-   * and byte array keys. {@link io.netty.buffer.ByteBuf} keys are always compared in native byte
-   * order and as unsigned.
-   */
-  MDB_UNSIGNEDKEY(0x30, false),
-  /**
    * With {@link #MDB_DUPSORT}, use reverse string dups.
    *
    * <p>This option specifies that duplicate data items should be compared as strings in reverse
@@ -78,24 +70,13 @@ public enum DbiFlags implements MaskedFlag {
   MDB_CREATE(0x4_0000);
 
   private final int mask;
-  private final boolean propagatedToLmdb;
-
-  DbiFlags(final int mask, final boolean propagatedToLmdb) {
-    this.mask = mask;
-    this.propagatedToLmdb = propagatedToLmdb;
-  }
 
   DbiFlags(final int mask) {
-    this(mask, true);
+    this.mask = mask;
   }
 
   @Override
   public int getMask() {
     return mask;
-  }
-
-  @Override
-  public boolean isPropagatedToLmdb() {
-    return propagatedToLmdb;
   }
 }

--- a/src/main/java/org/lmdbjava/DirectBufferProxy.java
+++ b/src/main/java/org/lmdbjava/DirectBufferProxy.java
@@ -111,12 +111,12 @@ public final class DirectBufferProxy extends BufferProxy<DirectBuffer> {
   }
 
   @Override
-  protected Comparator<DirectBuffer> getSignedComparator() {
+  public Comparator<DirectBuffer> getSignedComparator() {
     return signedComparator;
   }
 
   @Override
-  protected Comparator<DirectBuffer> getUnsignedComparator() {
+  public Comparator<DirectBuffer> getUnsignedComparator() {
     return unsignedComparator;
   }
 

--- a/src/main/java/org/lmdbjava/Env.java
+++ b/src/main/java/org/lmdbjava/Env.java
@@ -256,10 +256,17 @@ public final class Env<T> implements AutoCloseable {
 
   /**
    * Convenience method that opens a {@link Dbi} with a UTF-8 database name and associated {@link
-   * Comparator} that is not invoked from native code.
+   * Comparator} for use by {@link CursorIterable} when comparing start/stop keys.
+   * <p>
+   * It is very important that the passed comparator behaves in the same way as the comparator
+   * LMDB uses for its insertion order (for the type of data that will be stored in the database),
+   * or you fully understand the implications of them behaving differently.
+   * LMDB's comparator is unsigned lexicographical, unless {@link DbiFlags#MDB_INTEGERKEY} is used.
+   * </p>
    *
    * @param name name of the database (or null if no name is required)
-   * @param comparator custom comparator callback (or null to use default)
+   * @param comparator custom comparator for cursor start/stop key comparisons. If null,
+   *                   LMDB's comparator will be used.
    * @param flags to open the database with
    * @return a database that is ready to use
    */
@@ -271,11 +278,15 @@ public final class Env<T> implements AutoCloseable {
 
   /**
    * Convenience method that opens a {@link Dbi} with a UTF-8 database name and associated {@link
-   * Comparator} that may be invoked from native code if specified.
+   * Comparator}. The comparator will be used by {@link CursorIterable} when comparing start/stop keys
+   * as a minimum. If nativeCb is {@code true}, this comparator will also be called by LMDB to determine
+   * insertion/iteration order. Calling back to a java comparator may significantly impact performance.
    *
    * @param name name of the database (or null if no name is required)
-   * @param comparator custom comparator callback (or null to use default)
-   * @param nativeCb whether native code calls back to the Java comparator
+   * @param comparator custom comparator for cursor start/stop key comparisons and optionally for
+   *                   LMDB to call back to. If null,
+   *                   LMDB's comparator will be used.
+   * @param nativeCb whether LMDB native code calls back to the Java comparator
    * @param flags to open the database with
    * @return a database that is ready to use
    */

--- a/src/main/java/org/lmdbjava/Key.java
+++ b/src/main/java/org/lmdbjava/Key.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lmdbjava;
+
+import static java.util.Objects.requireNonNull;
+import static org.lmdbjava.BufferProxy.MDB_VAL_STRUCT_SIZE;
+import static org.lmdbjava.Library.RUNTIME;
+
+import jnr.ffi.Pointer;
+import jnr.ffi.provider.MemoryManager;
+
+/**
+ * Represents off-heap memory holding a key only.
+ *
+ * @param <T> buffer type
+ */
+final class Key<T> implements AutoCloseable {
+
+  private static final MemoryManager MEM_MGR = RUNTIME.getMemoryManager();
+  private boolean closed;
+  private T k;
+  private final BufferProxy<T> proxy;
+  private final Pointer ptrArray;
+  private final Pointer ptrKey;
+  private final long ptrKeyAddr;
+
+  Key(final BufferProxy<T> proxy) {
+    requireNonNull(proxy);
+    this.proxy = proxy;
+    this.k = proxy.allocate();
+    ptrKey = MEM_MGR.allocateTemporary(MDB_VAL_STRUCT_SIZE, false);
+    ptrKeyAddr = ptrKey.address();
+    ptrArray = MEM_MGR.allocateTemporary(MDB_VAL_STRUCT_SIZE * 2, false);
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    proxy.deallocate(k);
+  }
+
+  T key() {
+    return k;
+  }
+
+  void keyIn(final T key) {
+    proxy.in(key, ptrKey, ptrKeyAddr);
+  }
+
+  T keyOut() {
+    k = proxy.out(k, ptrKey, ptrKeyAddr);
+    return k;
+  }
+
+  Pointer pointerKey() {
+    return ptrKey;
+  }
+}

--- a/src/main/java/org/lmdbjava/KeyRangeType.java
+++ b/src/main/java/org/lmdbjava/KeyRangeType.java
@@ -322,12 +322,12 @@ public enum KeyRangeType {
    * @param start start buffer
    * @param stop stop buffer
    * @param buffer current key returned by LMDB (may be null)
-   * @param c comparator (required)
+   * @param rangeComparator comparator (required)
    * @return response to this key
    */
   <T, C extends Comparator<T>> IteratorOp iteratorOp(
-      final T start, final T stop, final T buffer, final C c) {
-    requireNonNull(c, "Comparator required");
+      final T start, final T stop, final T buffer, final RangeComparator rangeComparator) {
+    requireNonNull(rangeComparator, "Comparator required");
     if (buffer == null) {
       return TERMINATE;
     }
@@ -337,55 +337,55 @@ public enum KeyRangeType {
       case FORWARD_AT_LEAST:
         return RELEASE;
       case FORWARD_AT_MOST:
-        return c.compare(buffer, stop) > 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() > 0 ? TERMINATE : RELEASE;
       case FORWARD_CLOSED:
-        return c.compare(buffer, stop) > 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() > 0 ? TERMINATE : RELEASE;
       case FORWARD_CLOSED_OPEN:
-        return c.compare(buffer, stop) >= 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() >= 0 ? TERMINATE : RELEASE;
       case FORWARD_GREATER_THAN:
-        return c.compare(buffer, start) == 0 ? CALL_NEXT_OP : RELEASE;
+        return rangeComparator.compareToStartKey() == 0 ? CALL_NEXT_OP : RELEASE;
       case FORWARD_LESS_THAN:
-        return c.compare(buffer, stop) >= 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() >= 0 ? TERMINATE : RELEASE;
       case FORWARD_OPEN:
-        if (c.compare(buffer, start) == 0) {
+        if (rangeComparator.compareToStartKey() == 0) {
           return CALL_NEXT_OP;
         }
-        return c.compare(buffer, stop) >= 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() >= 0 ? TERMINATE : RELEASE;
       case FORWARD_OPEN_CLOSED:
-        if (c.compare(buffer, start) == 0) {
+        if (rangeComparator.compareToStartKey() == 0) {
           return CALL_NEXT_OP;
         }
-        return c.compare(buffer, stop) > 0 ? TERMINATE : RELEASE;
+        return rangeComparator.compareToStopKey() > 0 ? TERMINATE : RELEASE;
       case BACKWARD_ALL:
         return RELEASE;
       case BACKWARD_AT_LEAST:
-        return c.compare(buffer, start) > 0 ? CALL_NEXT_OP : RELEASE; // rewind
+        return rangeComparator.compareToStartKey() > 0 ? CALL_NEXT_OP : RELEASE; // rewind
       case BACKWARD_AT_MOST:
-        return c.compare(buffer, stop) >= 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() >= 0 ? RELEASE : TERMINATE;
       case BACKWARD_CLOSED:
-        if (c.compare(buffer, start) > 0) {
+        if (rangeComparator.compareToStartKey() > 0) {
           return CALL_NEXT_OP; // rewind
         }
-        return c.compare(buffer, stop) >= 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() >= 0 ? RELEASE : TERMINATE;
       case BACKWARD_CLOSED_OPEN:
-        if (c.compare(buffer, start) > 0) {
+        if (rangeComparator.compareToStartKey() > 0) {
           return CALL_NEXT_OP; // rewind
         }
-        return c.compare(buffer, stop) > 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() > 0 ? RELEASE : TERMINATE;
       case BACKWARD_GREATER_THAN:
-        return c.compare(buffer, start) >= 0 ? CALL_NEXT_OP : RELEASE;
+        return rangeComparator.compareToStartKey() >= 0 ? CALL_NEXT_OP : RELEASE;
       case BACKWARD_LESS_THAN:
-        return c.compare(buffer, stop) > 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() > 0 ? RELEASE : TERMINATE;
       case BACKWARD_OPEN:
-        if (c.compare(buffer, start) >= 0) {
+        if (rangeComparator.compareToStartKey() >= 0) {
           return CALL_NEXT_OP; // rewind
         }
-        return c.compare(buffer, stop) > 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() > 0 ? RELEASE : TERMINATE;
       case BACKWARD_OPEN_CLOSED:
-        if (c.compare(buffer, start) >= 0) {
+        if (rangeComparator.compareToStartKey() >= 0) {
           return CALL_NEXT_OP; // rewind
         }
-        return c.compare(buffer, stop) >= 0 ? RELEASE : TERMINATE;
+        return rangeComparator.compareToStopKey() >= 0 ? RELEASE : TERMINATE;
       default:
         throw new IllegalStateException("Invalid type");
     }

--- a/src/main/java/org/lmdbjava/Library.java
+++ b/src/main/java/org/lmdbjava/Library.java
@@ -235,6 +235,8 @@ final class Library {
 
     void mdb_txn_reset(@In Pointer txn);
 
+    int mdb_cmp(@In Pointer txn, @In Pointer dbi, @In Pointer key1, @In Pointer key2);
+
     Pointer mdb_version(IntByReference major, IntByReference minor, IntByReference patch);
   }
 }

--- a/src/main/java/org/lmdbjava/RangeComparator.java
+++ b/src/main/java/org/lmdbjava/RangeComparator.java
@@ -1,0 +1,19 @@
+package org.lmdbjava;
+
+/**
+ * For comparing a cursor's current key against a {@link KeyRange}'s start/stop key.
+ */
+interface RangeComparator {
+
+    /**
+     * Compare the cursor's current key to the range start key. Equivalent to compareTo(currentKey,
+     * startKey)
+     */
+    int compareToStartKey();
+
+    /**
+     * Compare the cursor's current key to the range stop key. Equivalent to compareTo(currentKey,
+     * stopKey)
+     */
+    int compareToStopKey();
+}

--- a/src/test/java/org/lmdbjava/ComparatorTest.java
+++ b/src/test/java/org/lmdbjava/ComparatorTest.java
@@ -135,7 +135,7 @@ public final class ComparatorTest {
 
     @Override
     public int compare(final byte[] o1, final byte[] o2) {
-      final Comparator<byte[]> c = PROXY_BA.getComparator();
+      final Comparator<byte[]> c = PROXY_BA.getUnsignedComparator();
       return c.compare(o1, o2);
     }
   }
@@ -145,7 +145,7 @@ public final class ComparatorTest {
 
     @Override
     public int compare(final byte[] o1, final byte[] o2) {
-      final Comparator<ByteBuffer> c = PROXY_OPTIMAL.getComparator();
+      final Comparator<ByteBuffer> c = PROXY_OPTIMAL.getUnsignedComparator();
 
       // Convert arrays to buffers that are larger than the array, with
       // limit set at the array length. One buffer bigger than the other.
@@ -189,7 +189,7 @@ public final class ComparatorTest {
     public int compare(final byte[] o1, final byte[] o2) {
       final DirectBuffer o1b = new UnsafeBuffer(o1);
       final DirectBuffer o2b = new UnsafeBuffer(o2);
-      final Comparator<DirectBuffer> c = PROXY_DB.getComparator();
+      final Comparator<DirectBuffer> c = PROXY_DB.getUnsignedComparator();
       return c.compare(o1b, o2b);
     }
   }
@@ -223,7 +223,7 @@ public final class ComparatorTest {
       final ByteBuf o2b = DEFAULT.directBuffer(o2.length);
       o1b.writeBytes(o1);
       o2b.writeBytes(o2);
-      final Comparator<ByteBuf> c = PROXY_NETTY.getComparator();
+      final Comparator<ByteBuf> c = PROXY_NETTY.getUnsignedComparator();
       return c.compare(o1b, o2b);
     }
   }

--- a/src/test/java/org/lmdbjava/CursorIterablePerfTest.java
+++ b/src/test/java/org/lmdbjava/CursorIterablePerfTest.java
@@ -1,0 +1,163 @@
+package org.lmdbjava;
+
+import static com.jakewharton.byteunits.BinaryByteUnit.GIBIBYTES;
+import static org.lmdbjava.DbiFlags.MDB_CREATE;
+import static org.lmdbjava.Env.create;
+import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
+import static org.lmdbjava.PutFlags.MDB_APPEND;
+import static org.lmdbjava.PutFlags.MDB_NOOVERWRITE;
+import static org.lmdbjava.TestUtils.POSIX_MODE;
+import static org.lmdbjava.TestUtils.bb;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CursorIterablePerfTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+//    private static final int ITERATIONS = 5_000_000;
+    private static final int ITERATIONS = 100_000;
+//    private static final int ITERATIONS = 10;
+
+    private Dbi<ByteBuffer> dbJavaComparator;
+    private Dbi<ByteBuffer> dbLmdbComparator;
+    private Dbi<ByteBuffer> dbCallbackComparator;
+    private List<Dbi<ByteBuffer>> dbs = new ArrayList<>();
+    private Env<ByteBuffer> env;
+    private List<Integer> data = new ArrayList<>(ITERATIONS);
+
+    @Before
+    public void before() throws IOException {
+        final File path = tmp.newFile();
+        final BufferProxy<ByteBuffer> bufferProxy = ByteBufferProxy.PROXY_OPTIMAL;
+        env =
+                create(bufferProxy)
+                        .setMapSize(GIBIBYTES.toBytes(1))
+                        .setMaxReaders(1)
+                        .setMaxDbs(3)
+                        .open(path, POSIX_MODE, MDB_NOSUBDIR);
+
+        // Use a java comparator for start/stop keys only
+        dbJavaComparator = env.openDbi("JavaComparator", bufferProxy.getUnsignedComparator(), MDB_CREATE);
+        // Use LMDB comparator for start/stop keys
+        dbLmdbComparator = env.openDbi("LmdbComparator", MDB_CREATE);
+        // Use a java comparator for start/stop keys and as a callback comparator
+        dbCallbackComparator = env.openDbi(
+                "CallBackComparator", bufferProxy.getUnsignedComparator(), true, MDB_CREATE);
+
+        dbs.add(dbJavaComparator);
+        dbs.add(dbLmdbComparator);
+        dbs.add(dbCallbackComparator);
+
+        populateList();
+    }
+
+    private void populateList() {
+        for (int i = 0; i < ITERATIONS * 2; i+=2) {
+            data.add(i);
+        }
+    }
+
+    private void populateDatabases(final boolean randomOrder) {
+        System.out.println("Clear then populate databases");
+
+        final List<Integer> data;
+        if (randomOrder) {
+            data = new ArrayList<>(this.data);
+            Collections.shuffle(data);
+        } else {
+            data = this.data;
+        }
+
+        for (int round = 0; round < 3; round++) {
+            System.out.println("round: " + round + " -----------------------------------------");
+
+            for (final Dbi<ByteBuffer> db : dbs) {
+                // Clean out the db first
+                try (Txn<ByteBuffer> txn = env.txnWrite();
+                     final Cursor<ByteBuffer> cursor = db.openCursor(txn)) {
+                    while (cursor.next()) {
+                        cursor.delete();
+                    }
+                }
+
+                final String dbName = new String(db.getName(), StandardCharsets.UTF_8);
+                final Instant start = Instant.now();
+                try (Txn<ByteBuffer> txn = env.txnWrite()) {
+                    for (final Integer i : data) {
+                        if (randomOrder) {
+                            db.put(txn, bb(i), bb(i + 1), MDB_NOOVERWRITE);
+                        } else {
+                            db.put(txn, bb(i), bb(i + 1), MDB_NOOVERWRITE, MDB_APPEND);
+                        }
+                    }
+                    txn.commit();
+                }
+                final Duration duration = Duration.between(start, Instant.now());
+                System.out.println("DB: " + dbName
+                        + " - Loaded in duration: " + duration
+                        + ", millis: " + duration.toMillis());
+            }
+        }
+    }
+
+    @After
+    public void after() {
+        env.close();
+        tmp.delete();
+    }
+
+    @Test
+    public void comparePerf_sequential() {
+        comparePerf(false);
+    }
+
+    @Test
+    public void comparePerf_random() {
+        comparePerf(true);
+    }
+
+    public void comparePerf(final boolean randomOrder) {
+        populateDatabases(randomOrder);
+        final ByteBuffer startKeyBuf = bb(data.getFirst());
+        final ByteBuffer stopKeyBuf = bb(data.getLast());
+        final KeyRange<ByteBuffer> keyRange = KeyRange.closed(startKeyBuf, stopKeyBuf);
+
+        System.out.println("\nIterating over all entries");
+        for (int round = 0; round < 3; round++) {
+            System.out.println("round: " + round + " -----------------------------------------");
+            for (final Dbi<ByteBuffer> db : dbs) {
+                final String dbName = new String(db.getName(), StandardCharsets.UTF_8);
+
+                final Instant start = Instant.now();
+                int cnt = 0;
+                // Exercise the stop key comparator on every entry
+                try (Txn<ByteBuffer> txn = env.txnRead();
+                     CursorIterable<ByteBuffer> c = db.iterate(txn, keyRange)) {
+                    for (final CursorIterable.KeyVal<ByteBuffer> kv : c) {
+                        cnt++;
+                    }
+                }
+                final Duration duration = Duration.between(start, Instant.now());
+                System.out.println("DB: " + dbName
+                        + " - Iterated in duration: " + duration
+                        + ", millis: " + duration.toMillis()
+                        + ", cnt: " + cnt);
+            }
+        }
+    }
+}

--- a/src/test/java/org/lmdbjava/DbiTest.java
+++ b/src/test/java/org/lmdbjava/DbiTest.java
@@ -111,7 +111,7 @@ public final class DbiTest {
   public void customComparator() {
     final Comparator<ByteBuffer> reverseOrder =
         (o1, o2) -> {
-          final int lexical = PROXY_OPTIMAL.getComparator().compare(o1, o2);
+          final int lexical = PROXY_OPTIMAL.getUnsignedComparator().compare(o1, o2);
           if (lexical == 0) {
             return 0;
           }
@@ -144,7 +144,7 @@ public final class DbiTest {
   @Test
   public void dbiWithComparatorThreadSafety() {
     final DbiFlags[] flags = new DbiFlags[] {MDB_CREATE, MDB_INTEGERKEY};
-    final Comparator<ByteBuffer> c = PROXY_OPTIMAL.getComparator(flags);
+    final Comparator<ByteBuffer> c = PROXY_OPTIMAL.getUnsignedComparator();
     final Dbi<ByteBuffer> db = env.openDbi(DB_1, c, true, flags);
 
     final List<Integer> keys = range(0, 1_000).boxed().collect(toList());

--- a/src/test/java/org/lmdbjava/KeyRangeTest.java
+++ b/src/test/java/org/lmdbjava/KeyRangeTest.java
@@ -195,7 +195,10 @@ public final class KeyRangeTest {
 
     IteratorOp op;
     do {
-      op = range.getType().iteratorOp(range.getStart(), range.getStop(), buff, Integer::compare);
+      final Integer finalBuff = buff;
+      final RangeComparator rangeComparator =
+          CursorIterable.createJavaRangeComparator(range, Integer::compareTo, () -> finalBuff);
+      op = range.getType().iteratorOp(range.getStart(), range.getStop(), buff, rangeComparator);
       switch (op) {
         case CALL_NEXT_OP:
           buff = cursor.apply(range.getType().nextOp(), range.getStart());

--- a/src/test/java/org/lmdbjava/TestUtils.java
+++ b/src/test/java/org/lmdbjava/TestUtils.java
@@ -30,6 +30,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 final class TestUtils {
 
   public static final String DB_1 = "test-db-1";
+  public static final String DB_2 = "test-db-2";
+  public static final String DB_3 = "test-db-3";
 
   public static final int POSIX_MODE = 0664;
 


### PR DESCRIPTION
Fixes #249

There are now essentially three ways of configuring comparators when creating a Dbi.

**null comparator**
LMDB will use its own comparator & CursorIterable will call down to mdb_cmp for comparisons between the current cursor key and the range start/stop key.

**provided comparator**
LMDB will use its own comparator & CursorIterable will use the provided comparator for comparisons between the current cursor key and the range start/stop key.

**provided comparator with nativeCb==true**
LMDB will call back to java for all comparator duties. CursorIterable will use the same provided comparator for comparisons between the current cursor key and the range start/stop key.

The methods `getSignedComparator()` and `getUnsignedComparator()` have been made public so users of this library can access them.