### PR TITLE
Make Env.closed volatile and document the close() lifecycle contract

### DIFF
--- a/src/main/java/org/lmdbjava/Env.java
+++ b/src/main/java/org/lmdbjava/Env.java
@@ -67,7 +67,16 @@ public final class Env<T> implements AutoCloseable {
    */
   public static final boolean SHOULD_CHECK = !getBoolean(DISABLE_CHECKS_PROP);
 
-  private boolean closed;
+  // volatile: close() may run on a different thread than the readers that call checkNotClosed().
+  // Without it there is no happens-before between the write here and those reads, so a reader could
+  // indefinitely observe a stale false (the JIT may even hoist the check out of a hot loop) and
+  // proceed into a native call on a freed env. This does NOT make close() atomic w.r.t. an
+  // in-flight
+  // txnRead()/txnWrite() (the check-then-mdb_txn_begin window in those methods remains); it removes
+  // the pure visibility bug and turns more of those races into a clean AlreadyClosedException
+  // rather
+  // than a JVM crash. See close() for the full lifecycle contract.
+  private volatile boolean closed;
   private final int maxKeySize;
   private final boolean noSubDir;
   private final BufferProxy<T> proxy;
@@ -131,6 +140,31 @@ public final class Env<T> implements AutoCloseable {
    * Close the handle.
    *
    * <p>Will silently return if already closed or never opened.
+   *
+   * <p><strong>Thread-safety / lifecycle contract.</strong> This method is <em>not</em>
+   * synchronized and (consistent with the package-level policy that LmdbJava provides no
+   * concurrency guarantees) it does not coordinate with other threads. Before and during this call
+   * the caller MUST ensure that:
+   *
+   * <ul>
+   *   <li>every {@link Txn}, {@link Cursor} and {@link Dbi} obtained from this environment has
+   *       already been closed; and
+   *   <li>no other thread is executing <em>any</em> operation on this environment or on a handle
+   *       derived from it — including {@link #txnRead()} / {@link #txnWrite()} and reads such as
+   *       {@code Dbi.get}.
+   * </ul>
+   *
+   * <p>Violating this contract is <strong>undefined behaviour that can crash the whole JVM</strong>
+   * ({@code SIGSEGV} on Linux/macOS, {@code EXCEPTION_ACCESS_VIOLATION 0xC0000005} on Windows); it
+   * does <em>not</em> raise a Java exception. The underlying {@code mdb_env_close} unmaps the
+   * memory map, so a transaction still being started or used on another thread then dereferences
+   * freed memory — typically observed as a native crash in {@code mdb_txn_renew0} / {@code
+   * mdb_txn_begin}.
+   *
+   * <p>If you must close an environment while reader threads may still be active, serialise the
+   * close against those readers in application code: e.g. a read/write lock where each reader holds
+   * the read lock for the entire duration of its transaction and {@code close()} holds the write
+   * lock, so the map is never unmapped while a read is in flight.
    */
   @Override
   public void close() {
@@ -568,7 +602,12 @@ public final class Env<T> implements AutoCloseable {
   /**
    * Obtain a read-only transaction.
    *
+   * <p>Must not race a concurrent {@link #close()} on another thread: the closed-check and the
+   * native transaction start are not atomic, so a close occurring between them can crash the JVM
+   * (see {@link #close()}).
+   *
    * @return a read-only transaction
+   * @throws Env.AlreadyClosedException if this environment has already been closed
    */
   public Txn<T> txnRead() {
     checkNotClosed();
@@ -578,7 +617,12 @@ public final class Env<T> implements AutoCloseable {
   /**
    * Obtain a read-write transaction.
    *
+   * <p>Must not race a concurrent {@link #close()} on another thread: the closed-check and the
+   * native transaction start are not atomic, so a close occurring between them can crash the JVM
+   * (see {@link #close()}).
+   *
    * @return a read-write transaction
+   * @throws Env.AlreadyClosedException if this environment has already been closed
    */
   public Txn<T> txnWrite() {
     checkNotClosed();


### PR DESCRIPTION
## Summary

Two **no-cost, no-behaviour-change** hardening changes for the close-during-read hazard that surfaces as a native `SIGSEGV` in `mdb_txn_renew0` under concurrent access. Motivated by #253 (whose crash stack is `mdb_txn_renew0 ← mdb_txn_begin ← containsAddress`), which I traced to closing an `Env` while a reader is still inside `txnRead()`/`mdb_txn_begin` on another thread.

Neither change adds locking to the hot path, consistent with the package policy that *"LmdbJava DO NOT provide any concurrency guarantees"*. They make the failure **less likely and clearly documented** without changing the zero-overhead contract. (A separate, opt-in follow-up PR proposes an actual drain-on-close guard for callers who want it — deliberately kept out of this PR.)

### C — `Env.closed` is now `volatile`
`close()` may run on a different thread than the readers calling `checkNotClosed()`. As a plain field there was no happens-before between the write and those reads, so a reader could indefinitely observe a stale `false` (the JIT may even hoist the check out of a hot loop) and proceed into a native call on a freed env.

`volatile` does **not** make `close()` atomic w.r.t. an in-flight `txnRead()`/`txnWrite()` — the check-then-`mdb_txn_begin` window remains — but it removes the pure visibility bug and turns more of those races into a clean `AlreadyClosedException` instead of a JVM crash. Cost is a single volatile read on paths that already read the field.

### D — document the lifecycle contract
`Env.close()` previously documented only *"silently return if already closed"*. It now spells out the contract LMDB's C API imposes but lmdbjava never surfaced: all txns/cursors/dbis must be closed and no other thread may be touching the env (or a derived handle) during `close()`, and violating this is **undefined behaviour that crashes the JVM (`SIGSEGV` / `EXCEPTION_ACCESS_VIOLATION 0xC0000005`), not a Java exception**. `txnRead()`/`txnWrite()` gain a cross-reference and `@throws AlreadyClosedException`.

## Test plan
- `EnvTest` 38/38 (covers idempotent `close()` and the existing `AlreadyClosedException` paths).
- `com.spotify.fmt:fmt-maven-plugin:check` clean (0/96 non-complying).
- No behavioural change to the default hot path.

Refs #253.