### PR TITLE
Proposal (fine to reject): opt-in safe close — Env.close(Duration) drains in-flight txns

### DIFF
--- a/src/main/java/org/lmdbjava/Env.java
+++ b/src/main/java/org/lmdbjava/Env.java
@@ -67,7 +67,16 @@ public final class Env<T> implements AutoCloseable {
    */
   public static final boolean SHOULD_CHECK = !getBoolean(DISABLE_CHECKS_PROP);
 
-  private boolean closed;
+  // volatile: close() may run on a different thread than the readers that call checkNotClosed().
+  // Without it there is no happens-before between the write here and those reads, so a reader could
+  // indefinitely observe a stale false (the JIT may even hoist the check out of a hot loop) and
+  // proceed into a native call on a freed env. This does NOT make close() atomic w.r.t. an
+  // in-flight
+  // txnRead()/txnWrite() (the check-then-mdb_txn_begin window in those methods remains); it removes
+  // the pure visibility bug and turns more of those races into a clean AlreadyClosedException
+  // rather
+  // than a JVM crash. See close() for the full lifecycle contract.
+  private volatile boolean closed;
   private final int maxKeySize;
   private final boolean noSubDir;
   private final BufferProxy<T> proxy;
@@ -131,6 +140,31 @@ public final class Env<T> implements AutoCloseable {
    * Close the handle.
    *
    * <p>Will silently return if already closed or never opened.
+   *
+   * <p><strong>Thread-safety / lifecycle contract.</strong> This method is <em>not</em>
+   * synchronized and (consistent with the package-level policy that LmdbJava provides no
+   * concurrency guarantees) it does not coordinate with other threads. Before and during this call
+   * the caller MUST ensure that:
+   *
+   * <ul>
+   *   <li>every {@link Txn}, {@link Cursor} and {@link Dbi} obtained from this environment has
+   *       already been closed; and
+   *   <li>no other thread is executing <em>any</em> operation on this environment or on a handle
+   *       derived from it — including {@link #txnRead()} / {@link #txnWrite()} and reads such as
+   *       {@code Dbi.get}.
+   * </ul>
+   *
+   * <p>Violating this contract is <strong>undefined behaviour that can crash the whole JVM</strong>
+   * ({@code SIGSEGV} on Linux/macOS, {@code EXCEPTION_ACCESS_VIOLATION 0xC0000005} on Windows); it
+   * does <em>not</em> raise a Java exception. The underlying {@code mdb_env_close} unmaps the
+   * memory map, so a transaction still being started or used on another thread then dereferences
+   * freed memory — typically observed as a native crash in {@code mdb_txn_renew0} / {@code
+   * mdb_txn_begin}.
+   *
+   * <p>If you must close an environment while reader threads may still be active, serialise the
+   * close against those readers in application code: e.g. a read/write lock where each reader holds
+   * the read lock for the entire duration of its transaction and {@code close()} holds the write
+   * lock, so the map is never unmapped while a read is in flight.
    */
   @Override
   public void close() {
@@ -568,7 +602,12 @@ public final class Env<T> implements AutoCloseable {
   /**
    * Obtain a read-only transaction.
    *
+   * <p>Must not race a concurrent {@link #close()} on another thread: the closed-check and the
+   * native transaction start are not atomic, so a close occurring between them can crash the JVM
+   * (see {@link #close()}).
+   *
    * @return a read-only transaction
+   * @throws Env.AlreadyClosedException if this environment has already been closed
    */
   public Txn<T> txnRead() {
     checkNotClosed();
@@ -578,7 +617,12 @@ public final class Env<T> implements AutoCloseable {
   /**
    * Obtain a read-write transaction.
    *
+   * <p>Must not race a concurrent {@link #close()} on another thread: the closed-check and the
+   * native transaction start are not atomic, so a close occurring between them can crash the JVM
+   * (see {@link #close()}).
+   *
    * @return a read-write transaction
+   * @throws Env.AlreadyClosedException if this environment has already been closed
    */
   public Txn<T> txnWrite() {
     checkNotClosed();

--- a/src/main/java/org/lmdbjava/Env.java
+++ b/src/main/java/org/lmdbjava/Env.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,6 +38,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 import jnr.ffi.Pointer;
 import jnr.ffi.byref.IntByReference;
@@ -77,6 +80,16 @@ public final class Env<T> implements AutoCloseable {
   // rather
   // than a JVM crash. See close() for the full lifecycle contract.
   private volatile boolean closed;
+
+  // Opt-in "safe close" (see Builder#setSafeClose). When enabled, live transactions are tracked so
+  // close(Duration) can drain in-flight readers before unmapping instead of risking the JVM crash
+  // documented on close(). All three fields are inert unless safeClose is true, so the default hot
+  // path is byte-for-byte unchanged: liveTxns is null and never touched, and the tracking branches
+  // are guarded by the final safeClose flag.
+  private final boolean safeClose;
+  private volatile boolean closing;
+  private final AtomicInteger liveTxns;
+
   private final int maxKeySize;
   private final boolean noSubDir;
   private final BufferProxy<T> proxy;
@@ -91,7 +104,8 @@ public final class Env<T> implements AutoCloseable {
       final boolean readOnly,
       final boolean noSubDir,
       final Path path,
-      final EnvFlagSet envFlagSet) {
+      final EnvFlagSet envFlagSet,
+      final boolean safeClose) {
     this.proxy = proxy;
     this.readOnly = readOnly;
     this.noSubDir = noSubDir;
@@ -100,6 +114,8 @@ public final class Env<T> implements AutoCloseable {
     this.maxKeySize = LIB.mdb_env_get_maxkeysize(ptr);
     this.path = path;
     this.envFlagSet = envFlagSet;
+    this.safeClose = safeClose;
+    this.liveTxns = safeClose ? new AtomicInteger() : null;
   }
 
   /**
@@ -173,6 +189,89 @@ public final class Env<T> implements AutoCloseable {
     }
     closed = true;
     LIB.mdb_env_close(ptr);
+  }
+
+  /**
+   * Close the handle, first draining any in-flight transactions ("safe close").
+   *
+   * <p>This is the opt-in, thread-safe counterpart to {@link #close()} and requires the environment
+   * to have been built with {@link Builder#setSafeClose(boolean) setSafeClose(true)} (otherwise an
+   * {@link IllegalStateException} is thrown). Unlike {@link #close()} it will <em>not</em> unmap
+   * the memory map while a transaction is still live, so it does not risk the JVM crash described
+   * on {@link #close()}.
+   *
+   * <p>On entry it stops new {@link #txnRead()} / {@link #txnWrite()} calls (they throw {@link
+   * AlreadyClosedException}), then waits up to {@code timeout} for every transaction obtained from
+   * this environment to be closed before calling the native close. If the timeout elapses with
+   * transactions still open it throws {@link CloseTimeoutException} and does <em>not</em> unmap
+   * (leaked or stuck transactions are a caller bug; forcing the unmap would reintroduce the crash).
+   *
+   * <p>Idempotent: returns immediately if the environment is already closed. This method only
+   * tracks transactions created <em>after</em> the environment was opened with safe close enabled;
+   * it cannot police direct native misuse or handles shared across processes.
+   *
+   * @param timeout maximum time to wait for in-flight transactions to drain
+   * @throws IllegalStateException if this environment was not built with safe close enabled
+   * @throws CloseTimeoutException if transactions remain open after {@code timeout}
+   */
+  public void close(final Duration timeout) {
+    requireNonNull(timeout);
+    if (!safeClose) {
+      throw new IllegalStateException(
+          "close(Duration) requires Env.Builder.setSafeClose(true); use close() otherwise");
+    }
+    if (closed) {
+      return;
+    }
+    // Publish "closing" before reading the live count. A reader increments liveTxns before reading
+    // closing (see beforeTxnBeginIfTracked); with both being volatile/atomic this handshake ensures
+    // that if the drain below observes zero live txns, any concurrent reader will observe closing
+    // and back out before it starts a native transaction. So the map is never unmapped under a live
+    // or about-to-start read.
+    closing = true;
+    final long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    while (liveTxns.get() > 0) {
+      if (System.nanoTime() - deadlineNanos >= 0L) {
+        throw new CloseTimeoutException(liveTxns.get());
+      }
+      LockSupport.parkNanos(500_000L); // 0.5 ms; close is rare, so a short poll is fine
+    }
+    closed = true;
+    LIB.mdb_env_close(ptr);
+  }
+
+  /**
+   * Registers a soon-to-begin transaction when safe close is enabled, and returns whether tracking
+   * happened so the caller can balance the count if {@code mdb_txn_begin} then fails. Must be
+   * called before the native transaction start so a concurrent {@link #close(Duration)} cannot
+   * unmap between the check and the begin.
+   */
+  private boolean beforeTxnBeginIfTracked() {
+    if (!safeClose) {
+      return false;
+    }
+    liveTxns.incrementAndGet();
+    if (closing || closed) {
+      liveTxns.decrementAndGet();
+      throw new AlreadyClosedException();
+    }
+    return true;
+  }
+
+  /** Balances {@link #beforeTxnBeginIfTracked()} when a tracked transaction is closed. */
+  void afterTxnClosed() {
+    if (safeClose) {
+      liveTxns.decrementAndGet();
+    }
+  }
+
+  /**
+   * Indicates whether this environment was built with the opt-in safe close enabled.
+   *
+   * @return true if {@link Builder#setSafeClose(boolean)} was set
+   */
+  public boolean isSafeClose() {
+    return safeClose;
   }
 
   /**
@@ -571,7 +670,15 @@ public final class Env<T> implements AutoCloseable {
   @Deprecated
   public Txn<T> txn(final Txn<T> parent, final TxnFlags... flags) {
     checkNotClosed();
-    return new Txn<>(this, parent, proxy, TxnFlagSet.of(flags));
+    final boolean tracked = beforeTxnBeginIfTracked();
+    try {
+      return new Txn<>(this, parent, proxy, TxnFlagSet.of(flags));
+    } catch (final RuntimeException e) {
+      if (tracked) {
+        liveTxns.decrementAndGet();
+      }
+      throw e;
+    }
   }
 
   /**
@@ -582,7 +689,15 @@ public final class Env<T> implements AutoCloseable {
    */
   public Txn<T> txn(final Txn<T> parent) {
     checkNotClosed();
-    return new Txn<>(this, parent, proxy, TxnFlagSet.EMPTY);
+    final boolean tracked = beforeTxnBeginIfTracked();
+    try {
+      return new Txn<>(this, parent, proxy, TxnFlagSet.EMPTY);
+    } catch (final RuntimeException e) {
+      if (tracked) {
+        liveTxns.decrementAndGet();
+      }
+      throw e;
+    }
   }
 
   /**
@@ -596,7 +711,15 @@ public final class Env<T> implements AutoCloseable {
    */
   public Txn<T> txn(final Txn<T> parent, final TxnFlagSet flags) {
     checkNotClosed();
-    return new Txn<>(this, parent, proxy, flags);
+    final boolean tracked = beforeTxnBeginIfTracked();
+    try {
+      return new Txn<>(this, parent, proxy, flags);
+    } catch (final RuntimeException e) {
+      if (tracked) {
+        liveTxns.decrementAndGet();
+      }
+      throw e;
+    }
   }
 
   /**
@@ -611,7 +734,15 @@ public final class Env<T> implements AutoCloseable {
    */
   public Txn<T> txnRead() {
     checkNotClosed();
-    return new Txn<>(this, null, proxy, TxnFlags.MDB_RDONLY_TXN);
+    final boolean tracked = beforeTxnBeginIfTracked();
+    try {
+      return new Txn<>(this, null, proxy, TxnFlags.MDB_RDONLY_TXN);
+    } catch (final RuntimeException e) {
+      if (tracked) {
+        liveTxns.decrementAndGet();
+      }
+      throw e;
+    }
   }
 
   /**
@@ -626,7 +757,15 @@ public final class Env<T> implements AutoCloseable {
    */
   public Txn<T> txnWrite() {
     checkNotClosed();
-    return new Txn<>(this, null, proxy, TxnFlagSet.EMPTY);
+    final boolean tracked = beforeTxnBeginIfTracked();
+    try {
+      return new Txn<>(this, null, proxy, TxnFlagSet.EMPTY);
+    } catch (final RuntimeException e) {
+      if (tracked) {
+        liveTxns.decrementAndGet();
+      }
+      throw e;
+    }
   }
 
   Pointer pointer() {
@@ -707,6 +846,23 @@ public final class Env<T> implements AutoCloseable {
     }
   }
 
+  /**
+   * {@link Env#close(Duration)} timed out because transactions were still open. The environment has
+   * <em>not</em> been closed (its memory map is still mapped); the caller should ensure the
+   * offending transactions are closed and retry, rather than forcing an unsafe {@link Env#close()}.
+   */
+  public static final class CloseTimeoutException extends LmdbException {
+
+    private static final long serialVersionUID = 1L;
+
+    CloseTimeoutException(final int openTransactions) {
+      super(
+          "close(Duration) timed out while "
+              + openTransactions
+              + " transaction(s) were still open");
+    }
+  }
+
   /** Object has already been opened and the operation is therefore prohibited. */
   public static final class AlreadyOpenException extends LmdbException {
 
@@ -735,6 +891,7 @@ public final class Env<T> implements AutoCloseable {
     private boolean opened;
     private final BufferProxy<T> proxy;
     private int mode = POSIX_MODE_DEFAULT;
+    private boolean safeClose;
     private final AbstractFlagSet.Builder<EnvFlags, EnvFlagSet> flagSetBuilder =
         EnvFlagSet.builder();
 
@@ -810,7 +967,7 @@ public final class Env<T> implements AutoCloseable {
         final boolean readOnly = flags.isSet(MDB_RDONLY_ENV);
         final boolean noSubDir = flags.isSet(MDB_NOSUBDIR);
         checkRc(LIB.mdb_env_open(ptr, path.toAbsolutePath().toString(), flags.getMask(), mode));
-        return new Env<>(proxy, ptr, readOnly, noSubDir, path, flags);
+        return new Env<>(proxy, ptr, readOnly, noSubDir, path, flags, safeClose);
       } catch (final LmdbNativeException e) {
         LIB.mdb_env_close(ptr);
         throw e;
@@ -874,6 +1031,27 @@ public final class Env<T> implements AutoCloseable {
         throw new AlreadyOpenException();
       }
       this.maxReaders = readers;
+      return this;
+    }
+
+    /**
+     * Enables the opt-in "safe close" for the resulting {@link Env}.
+     *
+     * <p>When enabled, the environment tracks its live transactions so {@link Env#close(Duration)}
+     * can drain in-flight readers before unmapping, instead of risking the JVM crash described on
+     * {@link Env#close()}. This adds a small amount of bookkeeping on transaction start/close; it
+     * is <strong>disabled by default</strong> so applications that already manage their own
+     * threading (the common low-latency case) pay nothing. It does not change the behaviour of the
+     * no-arg {@link Env#close()}.
+     *
+     * @param safeClose true to enable transaction tracking and {@link Env#close(Duration)}
+     * @return the builder
+     */
+    public Builder<T> setSafeClose(final boolean safeClose) {
+      if (opened) {
+        throw new AlreadyOpenException();
+      }
+      this.safeClose = safeClose;
       return this;
     }
 

--- a/src/main/java/org/lmdbjava/Txn.java
+++ b/src/main/java/org/lmdbjava/Txn.java
@@ -97,6 +97,9 @@ public final class Txn<T> implements AutoCloseable {
     }
     keyVal.close();
     state = RELEASED;
+    // Balance the registration performed by Env's txn factory when safe close is enabled. No-op
+    // otherwise. Runs once, since the RELEASED guard above makes close() idempotent.
+    env.afterTxnClosed();
   }
 
   /** Commits this transaction. */

--- a/src/test/java/org/lmdbjava/EnvSafeCloseTest.java
+++ b/src/test/java/org/lmdbjava/EnvSafeCloseTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.lmdbjava.DbiFlags.MDB_CREATE;
+import static org.lmdbjava.TestUtils.DB_1;
+import static org.lmdbjava.TestUtils.bb;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lmdbjava.Env.AlreadyClosedException;
+import org.lmdbjava.Env.CloseTimeoutException;
+
+/**
+ * Tests the opt-in "safe close" ({@link Env.Builder#setSafeClose(boolean)} + {@link
+ * Env#close(Duration)}). These deterministically exercise the close-during-read hazard that,
+ * without safe close, is undefined behaviour crashing the JVM in {@code mdb_txn_renew0} (see
+ * lmdbjava#253). With safe close enabled the same scenarios are safe, so they run green in the
+ * normal suite.
+ */
+public final class EnvSafeCloseTest {
+
+  private TempDir tempDir;
+
+  @BeforeEach
+  void beforeEach() {
+    tempDir = new TempDir();
+  }
+
+  @AfterEach
+  void afterEach() {
+    tempDir.cleanup();
+  }
+
+  private Env<ByteBuffer> openSafe() {
+    final Path dir = tempDir.createTempDir();
+    return Env.create().setMaxReaders(64).setMaxDbs(1).setSafeClose(true).open(dir);
+  }
+
+  @Test
+  void isSafeClose_reflectsBuilder() {
+    try (Env<ByteBuffer> safe = openSafe()) {
+      assertThat(safe.isSafeClose()).isTrue();
+    }
+    final Path dir = tempDir.createTempDir();
+    try (Env<ByteBuffer> plain = Env.create().setMaxDbs(1).open(dir)) {
+      assertThat(plain.isSafeClose()).isFalse();
+    }
+  }
+
+  @Test
+  void closeDuration_withoutSafeClose_throwsIllegalState() {
+    final Path dir = tempDir.createTempDir();
+    try (Env<ByteBuffer> plain = Env.create().setMaxDbs(1).open(dir)) {
+      assertThatThrownBy(() -> plain.close(Duration.ofSeconds(1)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Test
+  void closeDuration_withOpenTxn_timesOutAndDoesNotClose() {
+    final Env<ByteBuffer> env = openSafe();
+    env.createDbi().setDbName(DB_1).withDefaultComparator().addDbiFlag(MDB_CREATE).open();
+
+    final Txn<ByteBuffer> reader = env.txnRead(); // deliberately left open
+    assertThatThrownBy(() -> env.close(Duration.ofMillis(200)))
+        .isInstanceOf(CloseTimeoutException.class);
+    assertThat(env.isClosed()).isFalse(); // must NOT have unmapped with a live reader
+
+    reader.close();
+    env.close(Duration.ofSeconds(5)); // now drains cleanly
+    assertThat(env.isClosed()).isTrue();
+  }
+
+  @Test
+  void closeDuration_blocksUntilReaderCloses_thenRejectsNewTxns() throws Exception {
+    final Env<ByteBuffer> env = openSafe();
+    env.createDbi().setDbName(DB_1).withDefaultComparator().addDbiFlag(MDB_CREATE).open();
+
+    final Txn<ByteBuffer> reader = env.txnRead();
+    final CompletableFuture<Void> closeFuture =
+        CompletableFuture.runAsync(() -> env.close(Duration.ofSeconds(5)));
+
+    Thread.sleep(150);
+    assertThat(closeFuture).isNotDone(); // blocked on the live reader
+    assertThat(env.isClosed()).isFalse();
+
+    reader.close();
+    closeFuture.get(5, TimeUnit.SECONDS); // completes once the reader drained
+    assertThat(env.isClosed()).isTrue();
+    assertThatThrownBy(env::txnRead).isInstanceOf(AlreadyClosedException.class);
+  }
+
+  @Test
+  void closeDuration_isIdempotent() {
+    final Env<ByteBuffer> env = openSafe();
+    env.close(Duration.ofSeconds(1));
+    env.close(Duration.ofSeconds(1)); // no-op second call
+    assertThat(env.isClosed()).isTrue();
+  }
+
+  /**
+   * The core regression: hammer reads from many threads, then safe-close while reads are in flight.
+   * Without safe close this crashes the JVM; with it the close drains in-flight readers, later
+   * reads observe {@link AlreadyClosedException}, and the JVM survives.
+   */
+  @Test
+  void closeDuringConcurrentReads_survivesAndClosesCleanly() throws Exception {
+    final Env<ByteBuffer> env = openSafe();
+    final Dbi<ByteBuffer> db =
+        env.createDbi().setDbName(DB_1).withDefaultComparator().addDbiFlag(MDB_CREATE).open();
+    for (int i = 0; i < 32; i++) {
+      db.put(bb(i), bb(i));
+    }
+
+    final int readerCount = 16;
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final AtomicLong reads = new AtomicLong();
+    final List<Throwable> unexpected = new CopyOnWriteArrayList<>();
+    final List<Thread> readers = new ArrayList<>(readerCount);
+
+    for (int i = 0; i < readerCount; i++) {
+      final int seed = i;
+      final Thread reader =
+          new Thread(
+              () -> {
+                int k = seed;
+                while (!stop.get()) {
+                  try (Txn<ByteBuffer> txn = env.txnRead()) {
+                    db.get(txn, bb(k & 31));
+                    reads.incrementAndGet();
+                    k++;
+                  } catch (final AlreadyClosedException expected) {
+                    return; // benign: env is closing/closed
+                  } catch (final Throwable t) {
+                    unexpected.add(t);
+                    return;
+                  }
+                }
+              },
+              "reader-" + seed);
+      reader.setDaemon(true);
+      reader.start();
+      readers.add(reader);
+    }
+
+    Thread.sleep(100); // let readers saturate the native read path
+    env.close(Duration.ofSeconds(10)); // THE RACE, made safe by drain
+    stop.set(true);
+    for (final Thread reader : readers) {
+      reader.join(5_000);
+    }
+
+    assertThat(reads.get()).isGreaterThan(0L);
+    assertThat(unexpected).isEmpty();
+    assertThat(env.isClosed()).isTrue();
+  }
+}


### PR DESCRIPTION
## ⚠️ This is a proposal — please feel free to reject it

I want to be explicit up front: **it is completely reasonable to close this PR without merging.** There is a legitimate design position that this kind of guard does **not** belong in the library at all — that lmdbjava should stay a thin, zero-overhead binding that faithfully exposes LMDB's C thread/lifecycle rules, and that *serialising close against in-flight readers is the application's responsibility*, not the library's. That position is consistent with the package policy (*"LmdbJava DO NOT provide any concurrency guarantees … doing so would impose locking overhead on use cases that may not require it"*) and with @at055612's note on #253 that consumers should add *"their own concurrency control around the opening of txns as an added layer of java-side protection."*

I already fix this on my side in application code (a read/write lock: readers hold the read lock for the whole txn, close holds the write lock). So **nothing here is needed by me** — I'm offering it only in case you feel the recurring `mdb_txn_renew0` crash reports (#253 and similar) are worth an in-library, opt-in convenience. If you'd rather keep guards in the application layer, just say so and close it; no hard feelings, and the docs/volatile PR (#288) stands on its own regardless.

## What it does (only when explicitly opted in)

New `Builder.setSafeClose(boolean)` — **default `false`** — plus `Env.close(Duration)`:

- On entry it sets a volatile `closing` flag so new `txnRead()`/`txnWrite()` throw `AlreadyClosedException`, then waits up to the timeout for every live txn to be closed before calling the native `mdb_env_close`. The map is therefore **never unmapped while a read is in flight** → no `SIGSEGV` in `mdb_txn_renew0`.
- If txns remain open after the timeout it throws a new `CloseTimeoutException` and does **not** unmap (a leaked/stuck txn is a caller bug; forcing the unmap would reintroduce the crash). Idempotent; returns immediately if already closed.

**Correctness** rests on a two-flag handshake: a reader increments the live count (`AtomicInteger`, full fence) *before* reading `closing`; `close()` writes `closing` *before* reading the count. With both volatile/atomic, if the drain observes zero live txns then any concurrent reader observes `closing` and backs out before starting a native transaction. Registration happens in the `Env` txn factories before `mdb_txn_begin` (decrement on begin failure); `Txn.close()` decrements once.

**Zero cost when disabled:** `liveTxns` is `null` and never touched, every tracking branch is guarded by the `final safeClose` flag, and the no-arg `close()` is unchanged. Non-opting users pay nothing.

## Stacked on #288
This branch also contains the volatile/docs commit from #288, so this PR currently shows **two** commits; the first will drop out once #288 merges (or if you prefer, I can rebase this to stand alone).

## Test plan
- New `EnvSafeCloseTest` (6, all green): the flag, the `IllegalState` guard for `close(Duration)` without opt-in, timeout-without-close, block-until-drain + post-close rejection, idempotency, and a **concurrent close-during-read stress test that is safe precisely because of this feature** (it would crash the JVM on `master`).
- Existing `Env`/`Txn`/`Dbi`/`Cursor`/`Tutorial`/`GC` suites unaffected (safeClose defaults off).
- `fmt-maven-plugin:check` clean (0 non-complying).

Refs #253. Builds on #288.