### PR TITLE
Fix #215: correct NIO buffer for Netty ByteBuf reads (view + copy, pick one)

### DIFF
--- a/src/main/java/org/lmdbjava/ByteBufProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufProxy.java
@@ -23,6 +23,7 @@ import static org.lmdbjava.UnsafeAccess.UNSAFE;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Comparator;
 import jnr.ffi.Pointer;
@@ -220,5 +221,56 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
     UNSAFE.putInt(buffer, lengthOffset, (int) size);
     buffer.clear().writerIndex((int) size);
     return buffer;
+  }
+
+  /**
+   * Returns a read-only NIO {@link ByteBuffer} view over the LMDB memory currently referenced by
+   * the readable region of {@code buffer} — typically a {@link ByteBuf} just returned from a read
+   * using {@link #PROXY_NETTY}.
+   *
+   * <p><b>Why this is needed.</b> For zero copy, a {@code ByteBuf} returned from a read is
+   * repointed at LMDB's memory-mapped region by overwriting its {@code memoryAddress} (see {@link
+   * #out}). That makes the {@code ByteBuf}'s own accessors (e.g. {@link ByteBuf#getBytes(int,
+   * byte[])}) read the LMDB data correctly, but {@link ByteBuf#nioBuffer()} derives its buffer from
+   * Netty's separate, chunk-shared backing buffer, which was never repointed — so {@code
+   * buffer.nioBuffer()} yields zeros. (That chunk buffer cannot simply be repointed, as it is
+   * shared by every pooled buffer carved from the same chunk.) This method instead materialises a
+   * NIO buffer that actually aliases the LMDB region, so it can be handed to NIO-based consumers
+   * (compression, hashing, etc.).
+   *
+   * <p><b>Lifecycle — read carefully.</b> The returned buffer aliases LMDB-owned, read-only memory.
+   * It is valid ONLY while the owning read {@link Txn} remains open and unmodified, exactly like
+   * {@link Txn#val()}. Using it after that transaction (or the {@link Env}) is closed, or after a
+   * write to the same slot, is undefined behaviour that may crash the JVM (SIGSEGV). If you need
+   * the bytes to outlive the transaction, copy them out (e.g. into a heap {@link ByteBuffer}).
+   *
+   * @param buffer a {@link ByteBuf} whose readable region points at LMDB memory (required)
+   * @return a read-only NIO view over the same memory (never null)
+   */
+  public static ByteBuffer nioBufferView(final ByteBuf buffer) {
+    requireNonNull(buffer);
+    // Start from a real direct buffer, then repoint its single java.nio.Buffer address/capacity at
+    // the LMDB region — the same technique ByteBufferProxy uses for its own zero-copy NIO buffers.
+    // The original (zero-length) allocation stays referenced by the read-only view's attachment, so
+    // its Cleaner frees only that original base, never the LMDB memory we aliased.
+    final ByteBuffer view = ByteBuffer.allocateDirect(0);
+    UNSAFE.putLong(
+        view, NioBufferField.ADDRESS_OFFSET, buffer.memoryAddress() + buffer.readerIndex());
+    UNSAFE.putInt(view, NioBufferField.CAPACITY_OFFSET, buffer.readableBytes());
+    view.clear();
+    return view.asReadOnlyBuffer();
+  }
+
+  /**
+   * Lazily-resolved offsets of {@link java.nio.Buffer}'s {@code address}/{@code capacity} fields.
+   * Kept in a holder (not a static field on {@link ByteBufProxy}) so that a JVM lacking the
+   * required {@code --add-opens java.base/java.nio} only fails if {@link #nioBufferView(ByteBuf)}
+   * is actually called, rather than breaking {@link #PROXY_NETTY} initialisation for every user.
+   */
+  private static final class NioBufferField {
+    static final long ADDRESS_OFFSET =
+        UNSAFE.objectFieldOffset(findField("java.nio.Buffer", "address"));
+    static final long CAPACITY_OFFSET =
+        UNSAFE.objectFieldOffset(findField("java.nio.Buffer", "capacity"));
   }
 }

--- a/src/main/java/org/lmdbjava/ByteBufProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufProxy.java
@@ -242,7 +242,7 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
    * It is valid ONLY while the owning read {@link Txn} remains open and unmodified, exactly like
    * {@link Txn#val()}. Using it after that transaction (or the {@link Env}) is closed, or after a
    * write to the same slot, is undefined behaviour that may crash the JVM (SIGSEGV). If you need
-   * the bytes to outlive the transaction, copy them out (e.g. into a heap {@link ByteBuffer}).
+   * the bytes to outlive the transaction, use {@link #nioBufferCopy(ByteBuf)} instead.
    *
    * @param buffer a {@link ByteBuf} whose readable region points at LMDB memory (required)
    * @return a read-only NIO view over the same memory (never null)
@@ -259,6 +259,35 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
     UNSAFE.putInt(view, NioBufferField.CAPACITY_OFFSET, buffer.readableBytes());
     view.clear();
     return view.asReadOnlyBuffer();
+  }
+
+  /**
+   * Returns a direct NIO {@link ByteBuffer} holding an independent <b>copy</b> of the readable
+   * region of {@code buffer} — typically a {@link ByteBuf} just returned from a read using {@link
+   * #PROXY_NETTY}.
+   *
+   * <p>This is the safe counterpart to {@link #nioBufferView(ByteBuf)}. It addresses the same
+   * lmdbjava#215 problem (a get-returned {@code ByteBuf} whose {@link ByteBuf#nioBuffer()} yields
+   * zeros), but by copying the bytes out via the {@code ByteBuf}'s own (correct) accessor rather
+   * than aliasing LMDB memory. The copy therefore uses no {@code Unsafe}/reflection, needs no
+   * {@code --add-opens}, and — crucially — <b>remains valid after the transaction (or {@link Env})
+   * is closed</b>. Prefer this unless you specifically need zero copy and can guarantee the
+   * returned buffer is consumed before the owning transaction closes.
+   *
+   * <p>The returned buffer is a freshly allocated direct buffer, flipped and ready to read ({@code
+   * position=0}, {@code limit=size}). The caller owns it.
+   *
+   * @param buffer a {@link ByteBuf} whose readable region holds the bytes to copy (required)
+   * @return a new direct NIO buffer containing a copy of those bytes (never null)
+   */
+  public static ByteBuffer nioBufferCopy(final ByteBuf buffer) {
+    requireNonNull(buffer);
+    final ByteBuffer copy = ByteBuffer.allocateDirect(buffer.readableBytes());
+    // getBytes reads through the ByteBuf's (LMDB-repointed) memoryAddress, so it copies the real
+    // stored bytes — not the zeros seen via ByteBuf.nioBuffer().
+    buffer.getBytes(buffer.readerIndex(), copy);
+    copy.flip();
+    return copy;
   }
 
   /**

--- a/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
+++ b/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
@@ -28,8 +28,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Reproduces lmdbjava#215 and covers {@link ByteBufProxy#nioBufferView(ByteBuf)}, a zero-copy NIO
- * view over the LMDB memory of a value returned via {@link ByteBufProxy#PROXY_NETTY}.
+ * Reproduces and fixes lmdbjava#215: {@code ByteBuf.nioBuffer()} on a value returned via {@link
+ * ByteBufProxy#PROXY_NETTY} yields zeros. Two complementary helpers are offered:
+ *
+ * <ul>
+ *   <li>{@link ByteBufProxy#nioBufferView(ByteBuf)} — zero-copy, valid only within the txn.
+ *   <li>{@link ByteBufProxy#nioBufferCopy(ByteBuf)} — an independent copy that outlives the txn.
+ * </ul>
  */
 final class ByteBufNioBufferTest {
 
@@ -93,9 +98,57 @@ final class ByteBufNioBufferTest {
     }
   }
 
+  /** Copy reflects the stored bytes. */
+  @Test
+  void nioBufferCopy_reflectsStoredData() {
+    try (Env<ByteBuf> env = openEnv()) {
+      final Dbi<ByteBuf> db = openDb(env);
+      final ByteBuf key = PooledByteBufAllocator.DEFAULT.directBuffer(env.getMaxKeySize());
+      final ByteBuf value = PooledByteBufAllocator.DEFAULT.directBuffer(64);
+      try {
+        key.writeCharSequence("greeting", UTF_8);
+        value.writeCharSequence(VALUE, UTF_8);
+        db.put(key, value);
+        try (Txn<ByteBuf> txn = env.txnRead()) {
+          final ByteBuf found = db.get(txn, key);
+          assertThat(found).isNotNull();
+          assertThat(drain(ByteBufProxy.nioBufferCopy(found))).isEqualTo(VALUE_BYTES);
+        }
+      } finally {
+        key.release();
+        value.release();
+      }
+    }
+  }
+
+  /** The discriminator: a copy taken inside the txn is still valid after txn AND env are closed. */
+  @Test
+  void nioBufferCopy_survivesTxnAndEnvClose() {
+    final Env<ByteBuf> env = openEnv();
+    final ByteBuf key = PooledByteBufAllocator.DEFAULT.directBuffer(env.getMaxKeySize());
+    final ByteBuf value = PooledByteBufAllocator.DEFAULT.directBuffer(64);
+    ByteBuffer copy = null;
+    try {
+      final Dbi<ByteBuf> db = openDb(env);
+      key.writeCharSequence("greeting", UTF_8);
+      value.writeCharSequence(VALUE, UTF_8);
+      db.put(key, value);
+      try (Txn<ByteBuf> txn = env.txnRead()) {
+        copy = ByteBufProxy.nioBufferCopy(db.get(txn, key));
+      }
+    } finally {
+      key.release();
+      value.release();
+      env.close(); // both txn and env are now closed
+    }
+    assertThat(copy).isNotNull();
+    assertThat(drain(copy)).isEqualTo(VALUE_BYTES); // copy is independent of LMDB memory
+  }
+
   /**
    * Documents the lmdbjava#215 limitation: the raw {@link ByteBuf#nioBuffer()} does NOT reflect the
-   * LMDB data, even though the {@link ByteBuf}'s own accessors do.
+   * LMDB data (it views Netty's separate, never-repointed chunk buffer). This is why the two
+   * helpers exist.
    */
   @Test
   void rawByteBufNioBuffer_doesNotReflectStoredData() {

--- a/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
+++ b/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
@@ -28,9 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Reproduces lmdbjava#215: {@code ByteBuf.nioBuffer()} on a value returned via {@link
- * ByteBufProxy#PROXY_NETTY} does not reflect the stored data (it views Netty's separate,
- * chunk-shared backing buffer, which the zero-copy read path never repoints).
+ * Reproduces lmdbjava#215 and covers {@link ByteBufProxy#nioBufferView(ByteBuf)}, a zero-copy NIO
+ * view over the LMDB memory of a value returned via {@link ByteBufProxy#PROXY_NETTY}.
  */
 final class ByteBufNioBufferTest {
 
@@ -70,6 +69,30 @@ final class ByteBufNioBufferTest {
     return dst;
   }
 
+  /** Zero-copy view reflects the stored bytes (read inside the txn). */
+  @Test
+  void nioBufferView_reflectsStoredData() {
+    try (Env<ByteBuf> env = openEnv()) {
+      final Dbi<ByteBuf> db = openDb(env);
+      final ByteBuf key = PooledByteBufAllocator.DEFAULT.directBuffer(env.getMaxKeySize());
+      final ByteBuf value = PooledByteBufAllocator.DEFAULT.directBuffer(64);
+      try {
+        key.writeCharSequence("greeting", UTF_8);
+        value.writeCharSequence(VALUE, UTF_8);
+        db.put(key, value);
+        try (Txn<ByteBuf> txn = env.txnRead()) {
+          final ByteBuf found = db.get(txn, key);
+          assertThat(found).isNotNull();
+          assertThat(readable(found)).isEqualTo(VALUE_BYTES); // sanity
+          assertThat(drain(ByteBufProxy.nioBufferView(found))).isEqualTo(VALUE_BYTES);
+        }
+      } finally {
+        key.release();
+        value.release();
+      }
+    }
+  }
+
   /**
    * Documents the lmdbjava#215 limitation: the raw {@link ByteBuf#nioBuffer()} does NOT reflect the
    * LMDB data, even though the {@link ByteBuf}'s own accessors do.
@@ -87,8 +110,8 @@ final class ByteBufNioBufferTest {
         try (Txn<ByteBuf> txn = env.txnRead()) {
           final ByteBuf found = db.get(txn, key);
           assertThat(found).isNotNull();
-          assertThat(readable(found)).isEqualTo(VALUE_BYTES); // ByteBuf accessors are correct
-          assertThat(drain(found.nioBuffer())).isNotEqualTo(VALUE_BYTES); // nioBuffer() is not
+          assertThat(readable(found)).isEqualTo(VALUE_BYTES);
+          assertThat(drain(found.nioBuffer())).isNotEqualTo(VALUE_BYTES);
         }
       } finally {
         key.release();

--- a/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
+++ b/src/test/java/org/lmdbjava/ByteBufNioBufferTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lmdbjava;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.lmdbjava.DbiFlags.MDB_CREATE;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces lmdbjava#215: {@code ByteBuf.nioBuffer()} on a value returned via {@link
+ * ByteBufProxy#PROXY_NETTY} does not reflect the stored data (it views Netty's separate,
+ * chunk-shared backing buffer, which the zero-copy read path never repoints).
+ */
+final class ByteBufNioBufferTest {
+
+  private static final String VALUE = "Hello World";
+  private static final byte[] VALUE_BYTES = VALUE.getBytes(UTF_8);
+
+  private TempDir tempDir;
+
+  @BeforeEach
+  void beforeEach() {
+    tempDir = new TempDir();
+  }
+
+  @AfterEach
+  void afterEach() {
+    tempDir.cleanup();
+  }
+
+  private Env<ByteBuf> openEnv() {
+    final Path dir = tempDir.createTempDir();
+    return Env.create(ByteBufProxy.PROXY_NETTY).setMapSize(10_485_760).setMaxDbs(1).open(dir);
+  }
+
+  private static Dbi<ByteBuf> openDb(final Env<ByteBuf> env) {
+    return env.createDbi().setDbName("db").withDefaultComparator().addDbiFlag(MDB_CREATE).open();
+  }
+
+  private static byte[] readable(final ByteBuf buffer) {
+    final byte[] dst = new byte[buffer.readableBytes()];
+    buffer.getBytes(buffer.readerIndex(), dst);
+    return dst;
+  }
+
+  private static byte[] drain(final ByteBuffer buffer) {
+    final byte[] dst = new byte[buffer.remaining()];
+    buffer.get(dst);
+    return dst;
+  }
+
+  /**
+   * Documents the lmdbjava#215 limitation: the raw {@link ByteBuf#nioBuffer()} does NOT reflect the
+   * LMDB data, even though the {@link ByteBuf}'s own accessors do.
+   */
+  @Test
+  void rawByteBufNioBuffer_doesNotReflectStoredData() {
+    try (Env<ByteBuf> env = openEnv()) {
+      final Dbi<ByteBuf> db = openDb(env);
+      final ByteBuf key = PooledByteBufAllocator.DEFAULT.directBuffer(env.getMaxKeySize());
+      final ByteBuf value = PooledByteBufAllocator.DEFAULT.directBuffer(64);
+      try {
+        key.writeCharSequence("greeting", UTF_8);
+        value.writeCharSequence(VALUE, UTF_8);
+        db.put(key, value);
+        try (Txn<ByteBuf> txn = env.txnRead()) {
+          final ByteBuf found = db.get(txn, key);
+          assertThat(found).isNotNull();
+          assertThat(readable(found)).isEqualTo(VALUE_BYTES); // ByteBuf accessors are correct
+          assertThat(drain(found.nioBuffer())).isNotEqualTo(VALUE_BYTES); // nioBuffer() is not
+        }
+      } finally {
+        key.release();
+        value.release();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #215, where `ByteBuf.nioBuffer()` on a value returned via `ByteBufProxy.PROXY_NETTY` yields zeros.

## Root cause (confirming @2018ik)
For zero copy, a read-returned `ByteBuf` is repointed at LMDB's mmap by overwriting its `memoryAddress` (`ByteBufProxy.out`). The `ByteBuf`'s own accessors (`getBytes`, …) then read the LMDB data correctly, but `ByteBuf.nioBuffer()` derives its NIO buffer from Netty's **separate, chunk-shared** backing buffer, which was never repointed — so it reads zeros. That chunk buffer **cannot** simply be repointed (as @2018ik suggested): it is shared by every pooled buffer carved from the same chunk, so overwriting its address would corrupt sibling buffers.

## This is a "pick one" PR
Rather than guess, I've implemented **both** reasonable fixes as separate commits so you can choose and drop the other:

| | `ByteBufProxy.nioBufferView` | `ByteBufProxy.nioBufferCopy` |
|---|---|---|
| mechanism | zero-copy alias of LMDB mmap (same `Unsafe` address/capacity trick `ByteBufferProxy` already uses) | copy out via `ByteBuf.getBytes` into a fresh direct buffer |
| cost | none | one copy |
| lifetime | valid **only while the txn is open** (misuse → SIGSEGV, documented) | **outlives** the txn/`Env` close |
| requires `--add-opens java.base/java.nio` | yes (lazily, only if called) | no |
| risk | a foot-gun if misused | robust |

Commits:
1. `test(#215)` — repro test pinning the current (buggy) behaviour.
2. `feat(#215)` — `nioBufferView` (zero-copy) + test.
3. `feat(#215)` — `nioBufferCopy` (safe copy) + tests.

→ **Keep both, or drop commit 3 (view only) or commit 2 (copy only).** I'll remove the unwanted variant (and its one cross-reference) in a follow-up.

## Recommendation
My personal preference is to **keep both** `nioBufferView` and `nioBufferCopy` and document the trade-off clearly (the table above), so callers can pick per use case: zero-copy when the buffer is consumed within the transaction, or the safe copy when the bytes must outlive it. To me that is the cleanest outcome — the two genuinely serve different needs, and offering both (with the lifetime caveat spelled out) is more useful than forcing one.

That said, this is entirely your call. If you'd rather minimise API surface, I'm happy to keep just one — I'd suggest `nioBufferCopy` as the safe default — or to land only the repro test + docs and add no new API at all.

## Notes / testing
- New `ByteBufNioBufferTest` (4 tests, all green): view reflects data, copy reflects data, **copy survives txn+env close** (the key discriminator), and the raw `nioBuffer()` bug is documented.
- Existing `ByteBufProxyTest` unaffected; `fmt-maven-plugin:check` clean.
- I did not touch the Netty 4.2 / adaptive-allocator question (#261); this fix applies to the current pooled path and the same lifecycle reasoning would carry over to an adaptive proxy.