### PR TITLE
Iterator/stream: fix reverse-prefix bug + Spliterator SORTED contract, add coverage

### DIFF
--- a/src/main/java/org/lmdbjava/ByteArrayProxy.java
+++ b/src/main/java/org/lmdbjava/ByteArrayProxy.java
@@ -155,8 +155,11 @@ public final class ByteArrayProxy extends BufferProxy<byte[]> {
 
       // Check if byte is not at max unsigned value (0xFF = 255 = -1 in signed)
       if (b != (byte) 0xFF) {
-        final byte[] oneBigger = new byte[buffer.length];
-        System.arraycopy(buffer, 0, oneBigger, 0, buffer.length);
+        // Copy up to and including index i, dropping any trailing 0xFF bytes, then increment.
+        // This yields the tight prefix successor (e.g. {0x01,0xFF} -> {0x02}, not {0x02,0xFF}),
+        // so a reverse prefix scan does not over-shoot onto an unrelated higher key.
+        final byte[] oneBigger = new byte[i + 1];
+        System.arraycopy(buffer, 0, oneBigger, 0, i + 1);
         oneBigger[i] = (byte) (b + 1);
         return oneBigger;
       }

--- a/src/main/java/org/lmdbjava/ByteBufProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufProxy.java
@@ -244,7 +244,9 @@ public final class ByteBufProxy extends BufferProxy<ByteBuf> {
 
       // Check if byte is not at max unsigned value (0xFF = 255 = -1 in signed)
       if (b != (byte) 0xFF) {
-        final ByteBuf oneBigger = buffer.copy();
+        // Copy up to and including index i, dropping any trailing 0xFF bytes, then increment.
+        // This yields the tight prefix successor (e.g. {0x01,0xFF} -> {0x02}, not {0x02,0xFF}).
+        final ByteBuf oneBigger = buffer.copy(0, i + 1);
         oneBigger.setByte(i, (byte) (b + 1));
         return oneBigger;
       }

--- a/src/main/java/org/lmdbjava/ByteBufferProxy.java
+++ b/src/main/java/org/lmdbjava/ByteBufferProxy.java
@@ -322,10 +322,15 @@ public final class ByteBufferProxy {
 
           // Check if byte is not at max unsigned value (0xFF = 255 = -1 in signed)
           if (b != (byte) 0xFF) {
-            final ByteBuffer oneBigger = ByteBuffer.allocateDirect(buffer.remaining());
-            oneBigger.put(buffer.duplicate());
+            // Copy up to and including index i, dropping any trailing 0xFF bytes, then increment.
+            // This yields the tight prefix successor (e.g. {0x01,0xFF} -> {0x02}, not {0x02,0xFF}).
+            final int len = i - buffer.position() + 1;
+            final ByteBuffer src = buffer.duplicate();
+            src.limit(i + 1);
+            final ByteBuffer oneBigger = ByteBuffer.allocateDirect(len);
+            oneBigger.put(src);
             oneBigger.flip();
-            oneBigger.put(i - buffer.position(), (byte) (b + 1));
+            oneBigger.put(len - 1, (byte) (b + 1));
             return oneBigger;
           }
         }

--- a/src/main/java/org/lmdbjava/Dbi.java
+++ b/src/main/java/org/lmdbjava/Dbi.java
@@ -290,22 +290,17 @@ public final class Dbi<T> {
    * Obtains the name of this database, using the supplied {@link Charset}.
    *
    * @param charset The {@link Charset} to use when converting the DB from a byte[] to a {@link
-   *     String}.
+   *     String} (not null). Unmappable bytes are replaced, as per {@link String#String(byte[],
+   *     Charset)}.
    * @return The name of the database. If this is the unnamed database an empty string will be
    *     returned.
-   * @throws RuntimeException if the name can't be decoded.
    */
   public String getNameAsString(final Charset charset) {
+    requireNonNull(charset);
     if (name == null) {
       return "";
-    } else {
-      // Assume a UTF8 encoding as we don't know, thus swallow if it fails
-      try {
-        return new String(name, requireNonNull(charset));
-      } catch (Exception e) {
-        throw new RuntimeException("Unable to decode database name using charset " + charset);
-      }
     }
+    return new String(name, charset);
   }
 
   private RangeComparator createRangeComparator(
@@ -353,10 +348,29 @@ public final class Dbi<T> {
     }
   }
 
+  /**
+   * Iterate all entries in this database, forwards. See {@link #newIterate(Txn, KeyRange)} for
+   * important notes on single-use, closing, and the reused entry holder.
+   *
+   * @param txn transaction handle (not null; not committed)
+   * @return a single-use, closeable iterable (never null)
+   */
   public LmdbIterable<T> newIterate(final Txn<T> txn) {
     return newIterate(txn, KeyRange.all());
   }
 
+  /**
+   * Iterate the entries in this database over the given {@link KeyRange}.
+   *
+   * <p>The returned {@link LmdbIterable} may be iterated only once and holds a cursor open, so it
+   * MUST be closed (use try-with-resources). As with {@link CursorIterable}, each returned {@link
+   * CursorIterable.KeyVal} is a single reused holder whose contents change as iteration advances;
+   * copy the key/value out if you need to retain it beyond the current step.
+   *
+   * @param txn transaction handle (not null; not committed)
+   * @param keyRange range of keys to iterate (not null)
+   * @return a single-use, closeable iterable (never null)
+   */
   public LmdbIterable<T> newIterate(final Txn<T> txn, final KeyRange<T> keyRange) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);
@@ -393,10 +407,34 @@ public final class Dbi<T> {
     }
   }
 
+  /**
+   * Stream all entries in this database, forwards. See {@link #stream(Txn, KeyRange)} for important
+   * notes on the reused entry holder and closing the stream.
+   *
+   * @param txn transaction handle (not null; not committed)
+   * @return a closeable stream of key/value holders (never null)
+   */
   public Stream<CursorIterable.KeyVal<T>> stream(final Txn<T> txn) {
     return stream(txn, KeyRange.all());
   }
 
+  /**
+   * Stream the entries in this database over the given {@link KeyRange}.
+   *
+   * <p><strong>Important:</strong> the stream emits a single, reused {@link CursorIterable.KeyVal}
+   * holder — every element is the same object, mutated as the cursor advances. This is safe for
+   * one-at-a-time terminal operations (e.g. {@code forEach}), but any operation that retains or
+   * buffers more than one element (e.g. {@code collect(toList())}, {@code sorted()}, {@code
+   * distinct()}) will observe aliased entries. Extract the key/value into your own object within
+   * the pipeline if you need to retain them. The stream is {@code ORDERED} but not {@code SORTED}.
+   *
+   * <p>The returned stream holds a cursor open and MUST be closed; use it in a try-with-resources
+   * block. Valid only for the life of the passed read {@link Txn}.
+   *
+   * @param txn transaction handle (not null; not committed)
+   * @param keyRange range of keys to stream (not null)
+   * @return a closeable stream of key/value holders (never null)
+   */
   public Stream<CursorIterable.KeyVal<T>> stream(final Txn<T> txn, final KeyRange<T> keyRange) {
     if (SHOULD_CHECK) {
       requireNonNull(txn);

--- a/src/main/java/org/lmdbjava/DirectBufferProxy.java
+++ b/src/main/java/org/lmdbjava/DirectBufferProxy.java
@@ -268,10 +268,15 @@ public final class DirectBufferProxy extends BufferProxy<DirectBuffer> {
 
         // Check if byte is not at max unsigned value (0xFF = 255 = -1 in signed)
         if (b != (byte) 0xFF) {
-          final ByteBuffer oneBigger = ByteBuffer.allocateDirect(buffer.remaining());
-          oneBigger.put(buffer.duplicate());
+          // Copy up to and including index i, dropping any trailing 0xFF bytes, then increment.
+          // This yields the tight prefix successor (e.g. {0x01,0xFF} -> {0x02}, not {0x02,0xFF}).
+          final int len = i - buffer.position() + 1;
+          final ByteBuffer src = buffer.duplicate();
+          src.limit(i + 1);
+          final ByteBuffer oneBigger = ByteBuffer.allocateDirect(len);
+          oneBigger.put(src);
           oneBigger.flip();
-          oneBigger.put(i - buffer.position(), (byte) (b + 1));
+          oneBigger.put(len - 1, (byte) (b + 1));
           return new UnsafeBuffer(oneBigger);
         }
       }

--- a/src/main/java/org/lmdbjava/KeyRange.java
+++ b/src/main/java/org/lmdbjava/KeyRange.java
@@ -79,6 +79,42 @@ public final class KeyRange<T> {
     this.startKeyInclusive = startKeyInclusive;
     this.stopKeyInclusive = stopKeyInclusive;
     this.directionForward = directionForward;
+    // Derive the equivalent KeyRangeType so getType() is never null for builder-created ranges
+    // (a null type would NPE the legacy CursorIterable path).
+    this.type = deriveType(start, stop, startKeyInclusive, stopKeyInclusive, directionForward);
+  }
+
+  private static KeyRangeType deriveType(
+      final Object start,
+      final Object stop,
+      final boolean startInclusive,
+      final boolean stopInclusive,
+      final boolean forward) {
+    if (start == null && stop == null) {
+      return forward ? FORWARD_ALL : BACKWARD_ALL;
+    }
+    if (stop == null) {
+      if (forward) {
+        return startInclusive ? KeyRangeType.FORWARD_AT_LEAST : KeyRangeType.FORWARD_GREATER_THAN;
+      }
+      return startInclusive ? KeyRangeType.BACKWARD_AT_LEAST : KeyRangeType.BACKWARD_GREATER_THAN;
+    }
+    if (start == null) {
+      if (forward) {
+        return stopInclusive ? KeyRangeType.FORWARD_AT_MOST : KeyRangeType.FORWARD_LESS_THAN;
+      }
+      return stopInclusive ? KeyRangeType.BACKWARD_AT_MOST : KeyRangeType.BACKWARD_LESS_THAN;
+    }
+    if (forward) {
+      if (startInclusive) {
+        return stopInclusive ? KeyRangeType.FORWARD_CLOSED : KeyRangeType.FORWARD_CLOSED_OPEN;
+      }
+      return stopInclusive ? KeyRangeType.FORWARD_OPEN_CLOSED : KeyRangeType.FORWARD_OPEN;
+    }
+    if (startInclusive) {
+      return stopInclusive ? KeyRangeType.BACKWARD_CLOSED : KeyRangeType.BACKWARD_CLOSED_OPEN;
+    }
+    return stopInclusive ? KeyRangeType.BACKWARD_OPEN_CLOSED : KeyRangeType.BACKWARD_OPEN;
   }
 
   private KeyRange(final T prefix) {

--- a/src/main/java/org/lmdbjava/LmdbRangeComparator.java
+++ b/src/main/java/org/lmdbjava/LmdbRangeComparator.java
@@ -22,7 +22,7 @@ import jnr.ffi.Pointer;
 
 /**
  * Calls down to mdb_cmp to make use of the comparator that LMDB uses for insertion order. Has a
- * very slight overhead as compared to {@link CursorIterable.JavaRangeComparator}.
+ * very slight overhead as compared to {@link JavaRangeComparator}.
  */
 class LmdbRangeComparator<T> implements RangeComparator {
 

--- a/src/main/java/org/lmdbjava/LmdbStream.java
+++ b/src/main/java/org/lmdbjava/LmdbStream.java
@@ -62,7 +62,6 @@ public class LmdbStream {
             new LmdbRangeSpliterator<>(
                 cursor,
                 rangeComparator,
-                createEntryComparator(rangeComparator),
                 keyRange.getStart(),
                 keyRange.getStop(),
                 keyRange.isStartKeyInclusive(),
@@ -72,7 +71,6 @@ public class LmdbStream {
             new LmdbRangeReversedSpliterator<>(
                 cursor,
                 rangeComparator,
-                createReversedEntryComparator(rangeComparator),
                 keyRange.getStart(),
                 keyRange.getStop(),
                 keyRange.isStartKeyInclusive(),
@@ -80,12 +78,9 @@ public class LmdbStream {
       }
     } else {
       if (keyRange.directionForward) {
-        spliterator =
-            new LmdbSpliterator<>(cursor, rangeComparator, createEntryComparator(rangeComparator));
+        spliterator = new LmdbSpliterator<>(cursor, rangeComparator);
       } else {
-        spliterator =
-            new LmdbReversedSpliterator<>(
-                cursor, rangeComparator, createReversedEntryComparator(rangeComparator));
+        spliterator = new LmdbReversedSpliterator<>(cursor, rangeComparator);
       }
     }
     return spliterator;
@@ -97,15 +92,10 @@ public class LmdbStream {
     Boolean isFound;
     final KeyVal<T> entry = new KeyVal<>();
     final RangeComparator rangeComparator;
-    final Comparator<KeyVal<T>> entryComparator;
 
-    private LmdbSpliterator(
-        final Cursor<T> cursor,
-        final RangeComparator rangeComparator,
-        final Comparator<KeyVal<T>> entryComparator) {
+    private LmdbSpliterator(final Cursor<T> cursor, final RangeComparator rangeComparator) {
       this.cursor = cursor;
       this.rangeComparator = rangeComparator;
-      this.entryComparator = entryComparator;
     }
 
     @Override
@@ -152,34 +142,25 @@ public class LmdbStream {
 
     @Override
     public final int characteristics() {
-      return Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.NONNULL;
+      // Entries are produced in the DB's key order, but we do not expose a KeyVal comparator, so we
+      // must not advertise SORTED: a SORTED spliterator with a null getComparator() implies the
+      // elements use natural ordering, yet KeyVal does not implement Comparable. DISTINCT is also
+      // dropped because DUPSORT databases can yield multiple entries sharing the same key.
+      return Spliterator.ORDERED | Spliterator.NONNULL;
     }
 
     @Override
     public Comparator<? super KeyVal<T>> getComparator() {
-      return entryComparator;
+      // This spliterator does not report SORTED, so per the Spliterator contract getComparator()
+      // must throw rather than return null.
+      throw new IllegalStateException("Spliterator is ORDERED but not SORTED");
     }
-  }
-
-  private static <T> Comparator<KeyVal<T>> createEntryComparator(
-      final RangeComparator rangeComparator) {
-    return null;
-    //    return (o1, o2) -> comparator.compare(o1.key(), o2.key());
-  }
-
-  private static <T> Comparator<KeyVal<T>> createReversedEntryComparator(
-      final RangeComparator rangeComparator) {
-    return null;
-    //    return (o1, o2) -> comparator.compare(o1.key(), o2.key());
   }
 
   private static class LmdbReversedSpliterator<T> extends LmdbSpliterator<T> {
 
-    private LmdbReversedSpliterator(
-        final Cursor<T> cursor,
-        final RangeComparator rangeComparator,
-        final Comparator<KeyVal<T>> entryComparator) {
-      super(cursor, rangeComparator, entryComparator);
+    private LmdbReversedSpliterator(final Cursor<T> cursor, final RangeComparator rangeComparator) {
+      super(cursor, rangeComparator);
     }
 
     @Override
@@ -190,11 +171,6 @@ public class LmdbStream {
         isFound = cursor.prev();
       }
       return isFound;
-    }
-
-    @Override
-    public Comparator<? super KeyVal<T>> getComparator() {
-      return entryComparator;
     }
   }
 
@@ -209,12 +185,11 @@ public class LmdbStream {
     private LmdbRangeSpliterator(
         final Cursor<T> cursor,
         final RangeComparator rangeComparator,
-        final Comparator<KeyVal<T>> entryComparator,
         final T start,
         final T stop,
         final boolean startInclusive,
         final boolean stopInclusive) {
-      super(cursor, rangeComparator, entryComparator);
+      super(cursor, rangeComparator);
       this.rangeComparator = rangeComparator;
       this.start = start;
       this.stop = stop;
@@ -262,12 +237,11 @@ public class LmdbStream {
     private LmdbRangeReversedSpliterator(
         final Cursor<T> cursor,
         final RangeComparator rangeComparator,
-        final Comparator<KeyVal<T>> entryComparator,
         final T start,
         final T stop,
         final boolean startInclusive,
         final boolean stopInclusive) {
-      super(cursor, rangeComparator, entryComparator);
+      super(cursor, rangeComparator);
       this.rangeComparator = rangeComparator;
       this.start = start;
       this.stop = stop;
@@ -334,7 +308,7 @@ public class LmdbStream {
         final RangeComparator rangeComparator,
         final BufferProxy<T> proxy,
         final T prefix) {
-      super(cursor, rangeComparator, createEntryComparator(rangeComparator));
+      super(cursor, rangeComparator);
       this.proxy = proxy;
       this.prefix = prefix;
     }
@@ -366,7 +340,7 @@ public class LmdbStream {
         final RangeComparator rangeComparator,
         final BufferProxy<T> proxy,
         final T prefix) {
-      super(cursor, rangeComparator, createReversedEntryComparator(rangeComparator));
+      super(cursor, rangeComparator);
       this.proxy = proxy;
       this.prefix = prefix;
 

--- a/src/test/java/org/lmdbjava/BufferProxyPrefixTest.java
+++ b/src/test/java/org/lmdbjava/BufferProxyPrefixTest.java
@@ -95,13 +95,14 @@ final class BufferProxyPrefixTest {
 
   @ParameterizedTest
   @MethodSource("proxies")
-  void incrementCarriesOverTrailing0xFf(final Adapter adapter) {
-    // The trailing 0xFF byte is at its max, so the next non-0xFF byte to its left is incremented.
-    // NOTE: current behaviour KEEPS the trailing 0xFF bytes ({0x01,0xFF} -> {0x02,0xFF}) rather
-    // than truncating to the tight prefix-successor ({0x02}). This is consistent across all
-    // proxies; documented here so any future change to the successor semantics is caught.
-    assertThat(adapter.increment(bytes(0x01, 0xFF))).containsExactly(bytes(0x02, 0xFF));
-    assertThat(adapter.increment(bytes(0x01, 0xFF, 0xFF))).containsExactly(bytes(0x02, 0xFF, 0xFF));
+  void incrementTruncatesTrailing0xFfToTightSuccessor(final Adapter adapter) {
+    // When the least significant byte(s) are 0xFF, the next non-0xFF byte to the left is
+    // incremented and the trailing 0xFF bytes are dropped, giving the tight prefix successor.
+    // e.g. {0x01,0xFF} -> {0x02} (not {0x02,0xFF}); this prevents reverse prefix iteration from
+    // over-shooting onto an unrelated higher key.
+    assertThat(adapter.increment(bytes(0x01, 0xFF))).containsExactly(bytes(0x02));
+    assertThat(adapter.increment(bytes(0x01, 0xFF, 0xFF))).containsExactly(bytes(0x02));
+    assertThat(adapter.increment(bytes(0x12, 0xFF))).containsExactly(bytes(0x13));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/lmdbjava/BufferProxyPrefixTest.java
+++ b/src/test/java/org/lmdbjava/BufferProxyPrefixTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.lmdbjava.ByteArrayProxy.PROXY_BA;
+import static org.lmdbjava.ByteBufProxy.PROXY_NETTY;
+import static org.lmdbjava.ByteBufferProxy.PROXY_OPTIMAL;
+import static org.lmdbjava.DirectBufferProxy.PROXY_DB;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
+import java.util.stream.Stream;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for the prefix helpers {@link BufferProxy#containsPrefix} and {@link
+ * BufferProxy#incrementLeastSignificantByte} across every {@link BufferProxy} implementation.
+ *
+ * <p>These methods back the (reverse) prefix iteration added for gh-269 but had no direct unit
+ * coverage. Buffers are built in big-endian order (the default), so the "least significant byte" is
+ * the last byte, matching the byte-array behaviour.
+ */
+final class BufferProxyPrefixTest {
+
+  static Stream<Arguments> proxies() {
+    return Stream.of(
+        Arguments.argumentSet("ByteArrayProxy", new ByteArrayAdapter()),
+        Arguments.argumentSet("ByteBufferProxy", new ByteBufferAdapter()),
+        Arguments.argumentSet("DirectBufferProxy", new DirectBufferAdapter()),
+        Arguments.argumentSet("ByteBufProxy", new NettyAdapter()));
+  }
+
+  private static byte[] bytes(final int... values) {
+    final byte[] array = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      array[i] = (byte) values[i];
+    }
+    return array;
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void containsPrefixMatches(final Adapter adapter) {
+    // A shorter prefix that matches the leading bytes.
+    assertThat(adapter.containsPrefix(bytes(1, 2, 3, 4), bytes(1, 2))).isTrue();
+    // An identical buffer contains itself as a prefix.
+    assertThat(adapter.containsPrefix(bytes(1, 2, 3, 4), bytes(1, 2, 3, 4))).isTrue();
+    // The empty prefix is contained by anything (including the empty buffer).
+    assertThat(adapter.containsPrefix(bytes(1, 2, 3, 4), bytes())).isTrue();
+    assertThat(adapter.containsPrefix(bytes(), bytes())).isTrue();
+    // Unsigned byte comparison: 0x80 must be treated as greater than 0x01, not negative.
+    assertThat(adapter.containsPrefix(bytes(0x80, 0x00), bytes(0x80))).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void containsPrefixRejects(final Adapter adapter) {
+    // Same length, differing byte.
+    assertThat(adapter.containsPrefix(bytes(1, 2, 3, 4), bytes(1, 3))).isFalse();
+    // A prefix longer than the buffer can never be contained.
+    assertThat(adapter.containsPrefix(bytes(1, 2), bytes(1, 2, 3))).isFalse();
+    assertThat(adapter.containsPrefix(bytes(), bytes(1))).isFalse();
+    // Leading byte differs.
+    assertThat(adapter.containsPrefix(bytes(2, 2, 3, 4), bytes(1))).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void incrementSimple(final Adapter adapter) {
+    assertThat(adapter.increment(bytes(5))).containsExactly(bytes(6));
+    assertThat(adapter.increment(bytes(0))).containsExactly(bytes(1));
+    // Only the least significant (last) byte changes when it is not 0xFF.
+    assertThat(adapter.increment(bytes(0x12, 0x34))).containsExactly(bytes(0x12, 0x35));
+    assertThat(adapter.increment(bytes(0x12, 0xFE))).containsExactly(bytes(0x12, 0xFF));
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void incrementCarriesOverTrailing0xFf(final Adapter adapter) {
+    // The trailing 0xFF byte is at its max, so the next non-0xFF byte to its left is incremented.
+    // NOTE: current behaviour KEEPS the trailing 0xFF bytes ({0x01,0xFF} -> {0x02,0xFF}) rather
+    // than truncating to the tight prefix-successor ({0x02}). This is consistent across all
+    // proxies; documented here so any future change to the successor semantics is caught.
+    assertThat(adapter.increment(bytes(0x01, 0xFF))).containsExactly(bytes(0x02, 0xFF));
+    assertThat(adapter.increment(bytes(0x01, 0xFF, 0xFF))).containsExactly(bytes(0x02, 0xFF, 0xFF));
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void incrementReturnsNullWhenNoUpperBound(final Adapter adapter) {
+    // All bytes already at max unsigned value: no "one bigger" buffer exists.
+    assertThat(adapter.increment(bytes(0xFF))).isNull();
+    assertThat(adapter.increment(bytes(0xFF, 0xFF))).isNull();
+    // An empty buffer has no byte to increment.
+    assertThat(adapter.increment(bytes())).isNull();
+  }
+
+  /** Abstracts buffer construction so the same assertions run against every proxy type. */
+  interface Adapter {
+
+    boolean containsPrefix(byte[] buffer, byte[] prefix);
+
+    /**
+     * @return the incremented bytes, or null if the proxy returned null.
+     */
+    byte[] increment(byte[] buffer);
+  }
+
+  private static final class ByteArrayAdapter implements Adapter {
+
+    @Override
+    public boolean containsPrefix(final byte[] buffer, final byte[] prefix) {
+      return PROXY_BA.containsPrefix(buffer, prefix);
+    }
+
+    @Override
+    public byte[] increment(final byte[] buffer) {
+      return PROXY_BA.incrementLeastSignificantByte(buffer);
+    }
+  }
+
+  private static final class ByteBufferAdapter implements Adapter {
+
+    private static ByteBuffer bb(final byte[] bytes) {
+      final ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
+      buffer.put(bytes);
+      buffer.flip();
+      return buffer;
+    }
+
+    @Override
+    public boolean containsPrefix(final byte[] buffer, final byte[] prefix) {
+      return PROXY_OPTIMAL.containsPrefix(bb(buffer), bb(prefix));
+    }
+
+    @Override
+    public byte[] increment(final byte[] buffer) {
+      final ByteBuffer result = PROXY_OPTIMAL.incrementLeastSignificantByte(bb(buffer));
+      if (result == null) {
+        return null;
+      }
+      final ByteBuffer dup = result.duplicate();
+      final byte[] out = new byte[dup.remaining()];
+      dup.get(out);
+      return out;
+    }
+  }
+
+  private static final class DirectBufferAdapter implements Adapter {
+
+    private static UnsafeBuffer db(final byte[] bytes) {
+      // Wrap a direct ByteBuffer so DirectBufferProxy can read back its byteBuffer().
+      final ByteBuffer backing = ByteBuffer.allocateDirect(bytes.length);
+      backing.put(bytes);
+      backing.flip();
+      return new UnsafeBuffer(backing);
+    }
+
+    @Override
+    public boolean containsPrefix(final byte[] buffer, final byte[] prefix) {
+      return PROXY_DB.containsPrefix(db(buffer), db(prefix));
+    }
+
+    @Override
+    public byte[] increment(final byte[] buffer) {
+      final org.agrona.DirectBuffer result = PROXY_DB.incrementLeastSignificantByte(db(buffer));
+      if (result == null) {
+        return null;
+      }
+      final byte[] out = new byte[result.capacity()];
+      result.getBytes(0, out);
+      return out;
+    }
+  }
+
+  private static final class NettyAdapter implements Adapter {
+
+    private static ByteBuf nb(final byte[] bytes) {
+      // wrappedBuffer gives capacity == content length, which the Netty proxy relies on.
+      return Unpooled.wrappedBuffer(bytes);
+    }
+
+    @Override
+    public boolean containsPrefix(final byte[] buffer, final byte[] prefix) {
+      final ByteBuf b = nb(buffer);
+      final ByteBuf p = nb(prefix);
+      try {
+        return PROXY_NETTY.containsPrefix(b, p);
+      } finally {
+        b.release();
+        p.release();
+      }
+    }
+
+    @Override
+    public byte[] increment(final byte[] buffer) {
+      final ByteBuf b = nb(buffer);
+      try {
+        final ByteBuf result = PROXY_NETTY.incrementLeastSignificantByte(b);
+        if (result == null) {
+          return null;
+        }
+        try {
+          final byte[] out = new byte[result.capacity()];
+          result.getBytes(0, out);
+          return out;
+        } finally {
+          result.release();
+        }
+      } finally {
+        b.release();
+      }
+    }
+  }
+}

--- a/src/test/java/org/lmdbjava/CompareAsIntegerKeysTest.java
+++ b/src/test/java/org/lmdbjava/CompareAsIntegerKeysTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
+import java.util.stream.Stream;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Focused tests for the {@code compareAsIntegerKeys} static comparators on each integer-key capable
+ * proxy. {@link ComparatorIntegerKeyTest} already covers the numeric ordering semantics; this test
+ * targets the previously-uncovered branches: the length-mismatch guard and the fallback to
+ * lexicographic comparison when the key length is not 4 or 8 bytes.
+ */
+final class CompareAsIntegerKeysTest {
+
+  static Stream<Arguments> proxies() {
+    return Stream.of(
+        Arguments.argumentSet("ByteBufferProxy", new ByteBufferAdapter()),
+        Arguments.argumentSet("DirectBufferProxy", new DirectBufferAdapter()),
+        Arguments.argumentSet("ByteBufProxy", new NettyAdapter()));
+  }
+
+  private static byte[] bytes(final int... values) {
+    final byte[] array = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      array[i] = (byte) values[i];
+    }
+    return array;
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void lengthMismatchThrows(final Adapter adapter) {
+    assertThatThrownBy(() -> adapter.compare(bytes(0, 0, 0, 1), bytes(0, 0, 0, 0, 0, 0, 0, 1)))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void equalBytesCompareEqual(final Adapter adapter) {
+    assertThat(adapter.compare(bytes(1, 2, 3, 4), bytes(1, 2, 3, 4))).isZero();
+    assertThat(adapter.compare(bytes(1, 2, 3, 4, 5, 6, 7, 8), bytes(1, 2, 3, 4, 5, 6, 7, 8)))
+        .isZero();
+  }
+
+  @ParameterizedTest
+  @MethodSource("proxies")
+  void nonIntegerLengthFallsBackToLexicographic(final Adapter adapter) {
+    // 2-byte keys are neither 4 nor 8 bytes, so the comparator falls back to unsigned
+    // lexicographic.
+    assertThat(adapter.compare(bytes(0x00, 0x01), bytes(0x00, 0x02))).isNegative();
+    assertThat(adapter.compare(bytes(0x00, 0x02), bytes(0x00, 0x01))).isPositive();
+    assertThat(adapter.compare(bytes(0x12, 0x34), bytes(0x12, 0x34))).isZero();
+    // A single high-bit byte must be treated as unsigned (0x80 > 0x01), not as a negative byte.
+    assertThat(adapter.compare(bytes(0x80), bytes(0x01))).isPositive();
+  }
+
+  /** Normalises the differing static comparator signatures to a single byte[] based call. */
+  interface Adapter {
+    int compare(byte[] a, byte[] b);
+  }
+
+  private static final class ByteBufferAdapter implements Adapter {
+
+    private static ByteBuffer bb(final byte[] bytes) {
+      final ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
+      buffer.put(bytes);
+      buffer.flip();
+      return buffer;
+    }
+
+    @Override
+    public int compare(final byte[] a, final byte[] b) {
+      return ByteBufferProxy.AbstractByteBufferProxy.compareAsIntegerKeys(bb(a), bb(b));
+    }
+  }
+
+  private static final class DirectBufferAdapter implements Adapter {
+
+    @Override
+    public int compare(final byte[] a, final byte[] b) {
+      return DirectBufferProxy.compareAsIntegerKeys(new UnsafeBuffer(a), new UnsafeBuffer(b));
+    }
+  }
+
+  private static final class NettyAdapter implements Adapter {
+
+    @Override
+    public int compare(final byte[] a, final byte[] b) {
+      final ByteBuf ba = Unpooled.wrappedBuffer(a);
+      final ByteBuf bb = Unpooled.wrappedBuffer(b);
+      try {
+        return ByteBufProxy.compareAsIntegerKeys(ba, bb);
+      } finally {
+        ba.release();
+        bb.release();
+      }
+    }
+  }
+}

--- a/src/test/java/org/lmdbjava/DbiIterateApiTest.java
+++ b/src/test/java/org/lmdbjava/DbiIterateApiTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.lmdbjava.DbiFlags.MDB_CREATE;
+import static org.lmdbjava.Env.create;
+import static org.lmdbjava.EnvFlags.MDB_NOSUBDIR;
+import static org.lmdbjava.TestUtils.DB_1;
+import static org.lmdbjava.TestUtils.bb;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage for the newer {@link Dbi} iterate/stream API surface added for gh-269 that lacked direct
+ * tests: the {@link EntryConsumer} overloads of {@code newIterate}, the name accessors and {@code
+ * toString}, and the single-use guarantee of {@link LmdbIterable}.
+ */
+final class DbiIterateApiTest {
+
+  private TempDir tempDir;
+  private Env<ByteBuffer> env;
+  private Dbi<ByteBuffer> dbi;
+
+  @BeforeEach
+  void beforeEach() {
+    tempDir = new TempDir();
+    final Path file = tempDir.createTempFile();
+    env =
+        create()
+            .setMapSize(64, ByteUnit.MEBIBYTES)
+            .setMaxReaders(2)
+            .setMaxDbs(2)
+            .setEnvFlags(MDB_NOSUBDIR)
+            .open(file);
+    dbi = env.openDbi(DB_1, MDB_CREATE);
+    try (Txn<ByteBuffer> txn = env.txnWrite()) {
+      for (int i = 1; i <= 5; i++) {
+        dbi.put(txn, bb(i), bb(i));
+      }
+      txn.commit();
+    }
+  }
+
+  @AfterEach
+  void afterEach() {
+    env.close();
+    tempDir.cleanup();
+  }
+
+  @Test
+  void newIterateWithEntryConsumerVisitsEveryEntry() {
+    final List<Integer> keys = new ArrayList<>();
+    try (Txn<ByteBuffer> txn = env.txnRead()) {
+      dbi.newIterate(txn, (k, v) -> keys.add(k.getInt(0)));
+    }
+    assertThat(keys).containsExactly(1, 2, 3, 4, 5);
+  }
+
+  @Test
+  void newIterateWithEntryConsumerHonoursKeyRange() {
+    final List<Integer> keys = new ArrayList<>();
+    try (Txn<ByteBuffer> txn = env.txnRead()) {
+      dbi.newIterate(txn, KeyRange.closed(bb(2), bb(4)), (k, v) -> keys.add(k.getInt(0)));
+    }
+    assertThat(keys).containsExactly(2, 3, 4);
+  }
+
+  @Test
+  void streamCollectsRange() {
+    final List<Integer> keys;
+    try (Txn<ByteBuffer> txn = env.txnRead()) {
+      try (Stream<CursorIterable.KeyVal<ByteBuffer>> stream =
+          dbi.stream(txn, KeyRange.atLeast(bb(3)))) {
+        keys = stream.map(kv -> kv.key().getInt(0)).collect(Collectors.toList());
+      }
+    }
+    assertThat(keys).containsExactly(3, 4, 5);
+  }
+
+  @Test
+  void lmdbIterableIsSingleUse() {
+    try (Txn<ByteBuffer> txn = env.txnRead()) {
+      try (LmdbIterable<ByteBuffer> iterable = dbi.newIterate(txn)) {
+        iterable.iterator();
+        assertThatThrownBy(iterable::iterator).isInstanceOf(IllegalStateException.class);
+      }
+    }
+  }
+
+  @Test
+  void getNameAsStringForNamedDb() {
+    assertThat(dbi.getNameAsString()).isEqualTo(DB_1);
+    assertThat(dbi.getNameAsString(UTF_8)).isEqualTo(DB_1);
+  }
+
+  @Test
+  void getNameAsStringForUnnamedDbIsEmpty() {
+    final Dbi<ByteBuffer> unnamed = env.openDbi((byte[]) null, DbiFlagSet.EMPTY);
+    assertThat(unnamed.getNameAsString()).isEmpty();
+  }
+
+  @Test
+  void toStringContainsName() {
+    assertThat(dbi.toString()).contains(DB_1);
+  }
+}

--- a/src/test/java/org/lmdbjava/KeyRangeBuilderTest.java
+++ b/src/test/java/org/lmdbjava/KeyRangeBuilderTest.java
@@ -128,14 +128,31 @@ final class KeyRangeBuilderTest {
   }
 
   @Test
-  void builderAndPrefixRangesHaveNullType() {
-    // NOTE: documents current (surprising) behaviour. The private constructors used by builder()
-    // and prefix() never set `type`, so getType() is null for these ranges. The new
-    // LmdbIterable/LmdbStream paths only read directionForward/getPrefix/getStart/getStop, so this
-    // is currently harmless, but passing such a range to the legacy CursorIterable (Dbi.iterate),
-    // which calls getType(), would NPE. This assertion will flag the day that changes.
-    assertThat(KeyRange.builder().startInclusive(2).stopExclusive(8).build().getType()).isNull();
-    assertThat(KeyRange.builder().build().getType()).isNull();
+  void builderRangesExposeDerivedType() {
+    // Builder ranges now derive the equivalent KeyRangeType (previously getType() was null, which
+    // would NPE the legacy CursorIterable path).
+    assertThat(KeyRange.builder().startInclusive(2).stopExclusive(8).build().getType())
+        .isEqualTo(KeyRangeType.FORWARD_CLOSED_OPEN);
+    assertThat(KeyRange.builder().build().getType()).isEqualTo(KeyRangeType.FORWARD_ALL);
+    assertThat(
+            KeyRange.<Integer>builder()
+                .startExclusive(2)
+                .reverse()
+                .stopInclusive(8)
+                .build()
+                .getType())
+        .isEqualTo(KeyRangeType.BACKWARD_OPEN_CLOSED);
+    assertThat(KeyRange.<Integer>builder().startInclusive(2).build().getType())
+        .isEqualTo(KeyRangeType.FORWARD_AT_LEAST);
+    assertThat(KeyRange.<Integer>builder().stopExclusive(8).build().getType())
+        .isEqualTo(KeyRangeType.FORWARD_LESS_THAN);
+  }
+
+  @Test
+  void prefixRangesStillHaveNullType() {
+    // NOTE: prefix ranges have no equivalent KeyRangeType, so getType() remains null. They are only
+    // consumed by the new LmdbIterable/LmdbStream paths (which read directionForward/getPrefix),
+    // never the legacy CursorIterable path. This documents the remaining gap.
     assertThat(KeyRange.prefix(5).getType()).isNull();
     assertThat(KeyRange.prefixBackward(5).getType()).isNull();
   }

--- a/src/test/java/org/lmdbjava/KeyRangeBuilderTest.java
+++ b/src/test/java/org/lmdbjava/KeyRangeBuilderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link KeyRange} builder, prefix and start/stop-inclusive accessors added for gh-269.
+ *
+ * <p>{@link KeyRangeTest} already covers the iteration contract of the static {@link KeyRangeType}
+ * factories via a fake cursor; this test focuses on the newer construction paths and their exposed
+ * flags, which were largely uncovered.
+ */
+final class KeyRangeBuilderTest {
+
+  @Test
+  void builderForwardStartInclusiveStopExclusive() {
+    final KeyRange<Integer> range = KeyRange.builder().startInclusive(2).stopExclusive(8).build();
+    assertThat(range.getStart()).isEqualTo(2);
+    assertThat(range.getStop()).isEqualTo(8);
+    assertThat(range.isStartKeyInclusive()).isTrue();
+    assertThat(range.isStopKeyInclusive()).isFalse();
+    assertThat(range.isDirectionForward()).isTrue();
+    assertThat(range.getPrefix()).isNull();
+  }
+
+  @Test
+  void builderReversedStartExclusiveStopInclusive() {
+    final KeyRange<Integer> range =
+        KeyRange.<Integer>builder().startExclusive(2).reverse().stopInclusive(8).build();
+    assertThat(range.getStart()).isEqualTo(2);
+    assertThat(range.getStop()).isEqualTo(8);
+    assertThat(range.isStartKeyInclusive()).isFalse();
+    assertThat(range.isStopKeyInclusive()).isTrue();
+    assertThat(range.isDirectionForward()).isFalse();
+  }
+
+  @Test
+  void builderEmptyIsForwardAll() {
+    final KeyRange<Integer> range = KeyRange.builder().build();
+    assertThat(range.getStart()).isNull();
+    assertThat(range.getStop()).isNull();
+    assertThat(range.getPrefix()).isNull();
+    assertThat(range.isDirectionForward()).isTrue();
+  }
+
+  @Test
+  void builderReverseFlagToggles() {
+    assertThat(KeyRange.<Integer>builder().prefix(5).reverse(true).build().isDirectionForward())
+        .isFalse();
+    assertThat(KeyRange.<Integer>builder().prefix(5).reverse(false).build().isDirectionForward())
+        .isTrue();
+  }
+
+  @Test
+  void prefixBuilder() {
+    final KeyRange<Integer> range = KeyRange.builder().prefix(5).build();
+    assertThat(range.getPrefix()).isEqualTo(5);
+    assertThat(range.getStart()).isNull();
+    assertThat(range.getStop()).isNull();
+    assertThat(range.isDirectionForward()).isTrue();
+
+    final KeyRange<Integer> reversed = KeyRange.<Integer>builder().prefix(5).reverse().build();
+    assertThat(reversed.getPrefix()).isEqualTo(5);
+    assertThat(reversed.isDirectionForward()).isFalse();
+  }
+
+  @Test
+  void staticPrefixFactories() {
+    assertThat(KeyRange.prefix(5).getPrefix()).isEqualTo(5);
+    assertThat(KeyRange.prefix(5).isDirectionForward()).isTrue();
+    assertThat(KeyRange.prefixBackward(5).getPrefix()).isEqualTo(5);
+    assertThat(KeyRange.prefixBackward(5).isDirectionForward()).isFalse();
+  }
+
+  @Test
+  void nullPrefixRejected() {
+    assertThatThrownBy(() -> KeyRange.prefix(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> KeyRange.builder().prefix(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void staticFactoryInclusivityFlags() {
+    // closed  = [start, stop]
+    assertThat(KeyRange.closed(2, 8).isStartKeyInclusive()).isTrue();
+    assertThat(KeyRange.closed(2, 8).isStopKeyInclusive()).isTrue();
+    // open    = (start, stop)
+    assertThat(KeyRange.open(2, 8).isStartKeyInclusive()).isFalse();
+    assertThat(KeyRange.open(2, 8).isStopKeyInclusive()).isFalse();
+    // closedOpen = [start, stop)
+    assertThat(KeyRange.closedOpen(2, 8).isStartKeyInclusive()).isTrue();
+    assertThat(KeyRange.closedOpen(2, 8).isStopKeyInclusive()).isFalse();
+    // openClosed = (start, stop]
+    assertThat(KeyRange.openClosed(2, 8).isStartKeyInclusive()).isFalse();
+    assertThat(KeyRange.openClosed(2, 8).isStopKeyInclusive()).isTrue();
+    // single-bound ranges
+    assertThat(KeyRange.atLeast(2).isStartKeyInclusive()).isTrue();
+    assertThat(KeyRange.greaterThan(2).isStartKeyInclusive()).isFalse();
+    assertThat(KeyRange.atMost(8).isStopKeyInclusive()).isTrue();
+    assertThat(KeyRange.lessThan(8).isStopKeyInclusive()).isFalse();
+  }
+
+  @Test
+  void staticFactoriesExposeType() {
+    assertThat(KeyRange.all().getType()).isEqualTo(KeyRangeType.FORWARD_ALL);
+    assertThat(KeyRange.allBackward().getType()).isEqualTo(KeyRangeType.BACKWARD_ALL);
+    assertThat(KeyRange.closed(2, 8).getType()).isEqualTo(KeyRangeType.FORWARD_CLOSED);
+    assertThat(KeyRange.all().isDirectionForward()).isTrue();
+    assertThat(KeyRange.allBackward().isDirectionForward()).isFalse();
+  }
+
+  @Test
+  void builderAndPrefixRangesHaveNullType() {
+    // NOTE: documents current (surprising) behaviour. The private constructors used by builder()
+    // and prefix() never set `type`, so getType() is null for these ranges. The new
+    // LmdbIterable/LmdbStream paths only read directionForward/getPrefix/getStart/getStop, so this
+    // is currently harmless, but passing such a range to the legacy CursorIterable (Dbi.iterate),
+    // which calls getType(), would NPE. This assertion will flag the day that changes.
+    assertThat(KeyRange.builder().startInclusive(2).stopExclusive(8).build().getType()).isNull();
+    assertThat(KeyRange.builder().build().getType()).isNull();
+    assertThat(KeyRange.prefix(5).getType()).isNull();
+    assertThat(KeyRange.prefixBackward(5).getType()).isNull();
+  }
+}

--- a/src/test/java/org/lmdbjava/LmdbPrefixReversedSuccessorTest.java
+++ b/src/test/java/org/lmdbjava/LmdbPrefixReversedSuccessorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.lmdbjava.ByteArrayProxy.PROXY_BA;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for reverse prefix iteration when the prefix ends in {@code 0xFF}.
+ *
+ * <p>Reverse prefix iteration seeks to the "prefix successor" (one greater than the prefix) and
+ * steps back. If that successor over-shoots — e.g. prefix {@code {0x01,0xFF}} producing {@code
+ * {0x02,0xFF}} instead of the tight {@code {0x02}} — an unrelated higher key that sorts between the
+ * last prefix match and the over-shot successor is landed on, the prefix check fails, and iteration
+ * wrongly yields nothing.
+ */
+final class LmdbPrefixReversedSuccessorTest {
+
+  private static byte[] key(final int... values) {
+    final byte[] array = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      array[i] = (byte) values[i];
+    }
+    return array;
+  }
+
+  @Test
+  void reversePrefixEndingInFfReturnsAllMatches() throws IOException {
+    final byte[] prefix = key(0x01, 0xFF);
+    // Expected matches, in reverse (descending) order.
+    final byte[] match2 = key(0x01, 0xFF, 0x05);
+    final byte[] match1 = key(0x01, 0xFF);
+
+    final Path path = Files.createTempDirectory("lmdb");
+    try (Env<byte[]> env = Env.create(PROXY_BA).setMapSize(1, ByteUnit.MEBIBYTES).open(path)) {
+      final Dbi<byte[]> dbi =
+          env.openDbi("test".getBytes(StandardCharsets.UTF_8), DbiFlags.MDB_CREATE);
+      try (Txn<byte[]> txn = env.txnWrite()) {
+        final byte[] empty = new byte[0];
+        dbi.put(txn, match1, empty);
+        dbi.put(txn, match2, empty);
+        // An unrelated key that sorts just above the prefix range and below an over-shot successor.
+        dbi.put(txn, key(0x02, 0x00), empty);
+        txn.commit();
+      }
+
+      try (Txn<byte[]> txn = env.txnRead()) {
+        // LmdbIterable path.
+        final List<byte[]> viaIterable = new ArrayList<>();
+        try (LmdbIterable<byte[]> it = dbi.newIterate(txn, KeyRange.prefixBackward(prefix))) {
+          for (final CursorIterable.KeyVal<byte[]> kv : it) {
+            viaIterable.add(kv.key().clone());
+          }
+        }
+        assertThat(viaIterable).containsExactly(match2, match1);
+
+        // LmdbStream path (uses the same prefix-successor logic).
+        final List<byte[]> viaStream;
+        try (Stream<CursorIterable.KeyVal<byte[]>> s =
+            dbi.stream(txn, KeyRange.prefixBackward(prefix))) {
+          viaStream = s.map(kv -> kv.key().clone()).collect(toList());
+        }
+        assertThat(viaStream).containsExactly(match2, match1);
+      }
+    } catch (final UncheckedIOException e) {
+      throw e;
+    } finally {
+      FileUtil.deleteDir(path);
+    }
+  }
+}

--- a/src/test/java/org/lmdbjava/LmdbStreamCharacteristicsTest.java
+++ b/src/test/java/org/lmdbjava/LmdbStreamCharacteristicsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2016-2025 The LmdbJava Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lmdbjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@link Spliterator} contract reported by {@link LmdbStream}.
+ *
+ * <p>The stream produces entries in the database's key order but does not expose a {@link
+ * java.util.Comparator} over {@link CursorIterable.KeyVal}. It must therefore report {@code
+ * ORDERED} but not {@code SORTED}, and {@link Spliterator#getComparator()} must throw as required
+ * by the contract for a non-sorted spliterator.
+ */
+final class LmdbStreamCharacteristicsTest {
+
+  @Test
+  void reportsOrderedNonNullButNotSortedOrDistinct() {
+    withStreamSpliterator(
+        spliterator -> {
+          assertThat(spliterator.hasCharacteristics(Spliterator.ORDERED)).isTrue();
+          assertThat(spliterator.hasCharacteristics(Spliterator.NONNULL)).isTrue();
+          assertThat(spliterator.hasCharacteristics(Spliterator.SORTED)).isFalse();
+          assertThat(spliterator.hasCharacteristics(Spliterator.DISTINCT)).isFalse();
+        });
+  }
+
+  @Test
+  void getComparatorThrowsBecauseNotSorted() {
+    withStreamSpliterator(
+        spliterator ->
+            assertThatThrownBy(spliterator::getComparator)
+                .isInstanceOf(IllegalStateException.class));
+  }
+
+  private void withStreamSpliterator(
+      final Consumer<Spliterator<CursorIterable.KeyVal<ByteBuffer>>> assertion) {
+    try {
+      final Path path = Files.createTempDirectory("lmdb");
+      try (final Env<ByteBuffer> env = Env.create().setMapSize(1, ByteUnit.MEBIBYTES).open(path)) {
+        final Dbi<ByteBuffer> dbi =
+            env.openDbi("test".getBytes(StandardCharsets.UTF_8), DbiFlags.MDB_CREATE);
+        try (final Txn<ByteBuffer> txn = env.txnWrite()) {
+          final ByteBuffer value = ByteBuffer.allocateDirect(0);
+          for (int i = 0; i < 5; i++) {
+            final ByteBuffer key = ByteBuffer.allocateDirect(Integer.BYTES);
+            key.putInt(i).flip();
+            dbi.put(txn, key, value);
+          }
+          txn.commit();
+        }
+        try (final Txn<ByteBuffer> txn = env.txnRead()) {
+          try (final Stream<CursorIterable.KeyVal<ByteBuffer>> stream =
+              dbi.stream(txn, KeyRange.all())) {
+            assertion.accept(stream.spliterator());
+          }
+        }
+      }
+      FileUtil.deleteDir(path);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
Follow-up work stacked on the `iterator-performance` branch (targets that branch, **not** `master`). It fixes two correctness/contract issues in the new iterator/stream code, adds the missing unit/integration coverage for the gh-269 helpers, and tidies a few related items. All changes are additive or self-contained; the design decisions on the branch (see "Deliberately left open" below) are untouched.

## Fixes

### 1. Reverse prefix iteration silently drops rows when the prefix ends in `0xFF`
`BufferProxy.incrementLeastSignificantByte` computed the "prefix successor" by incrementing the least-significant non-`0xFF` byte but **keeping the trailing `0xFF` bytes** — e.g. `{0x01,0xFF}` → `{0x02,0xFF}` instead of the tight `{0x02}`.

In `LmdbPrefixReversedIterator`/`LmdbPrefixReversedSpliterator` the successor is used to `MDB_SET_RANGE` past the prefix range and step back. When it over-shoots, an unrelated higher key that sorts between the last prefix match and the over-shot successor is landed on, the `containsPrefix` check fails, and iteration wrongly yields **nothing**.

- Reproduced by `LmdbPrefixReversedSuccessorTest` (keys `{0x01,0xFF}`, `{0x01,0xFF,0x05}`, `{0x02,0x00}`; reverse-prefix `{0x01,0xFF}` returned `[]` before the fix).
- Fixed by truncating trailing `0xFF` (tight successor) across all four proxies' big-endian byte-string branch (ByteArray, ByteBuffer, DirectBuffer, Netty). The little-endian/integer-key branch is left as-is — prefix scans operate on big-endian byte strings.

### 2. `LmdbStream` Spliterator advertised `SORTED` with a `null` comparator
`createEntryComparator`/`createReversedEntryComparator` returned `null` (real body commented out), yet every spliterator reported `ORDERED | DISTINCT | SORTED | NONNULL` and `getComparator()` returned that `null`. A `SORTED` spliterator with a `null` comparator implies natural ordering, but `KeyVal` is not `Comparable`.

- Dropped `SORTED` and `DISTINCT` (DUPSORT can repeat keys) → `ORDERED | NONNULL`.
- `getComparator()` now throws `IllegalStateException`, as required for a non-sorted spliterator.
- Removed the dead `entryComparator` plumbing (also clears the "useless `rangeComparator` parameter" scan alerts).
- Note: a real `Comparator<KeyVal<T>>` + `SORTED` isn't safe without first emitting per-element snapshots, because the spliterator emits a single reused `KeyVal` (`collect(toList())` returns one aliased instance for every row). That's a larger design change and is left to the maintainers.

### 3. `KeyRange.getType()` returned `null` for builder-created ranges
The private constructors used by `KeyRange.builder()` never set `type`, so `getType()` returned `null` and would NPE the legacy `CursorIterable` path. Builder/empty ranges now derive the equivalent `KeyRangeType`. Prefix ranges still have no `KeyRangeType` (documented) as they are only consumed by the new iterators.

## Tidy-ups
- `Dbi.stream()`/`newIterate()` javadoc now warns that entries are a single reused `KeyVal` holder (so `collect`/`sorted`/`distinct` observe aliased entries) and that the stream is `ORDERED` but not `SORTED`.
- `Dbi.getNameAsString(Charset)`: removed a dead `try/catch` and misleading "assume UTF8" comment (`new String(byte[], Charset)` never throws).
- Fixed a stale javadoc link `CursorIterable.JavaRangeComparator` → `JavaRangeComparator`.

## New/updated tests
- `BufferProxyPrefixTest` — `containsPrefix` + `incrementLeastSignificantByte` across all four proxies, incl. edge cases (empty/oversized prefix, unsigned bytes, trailing-`0xFF` truncation, all-`0xFF` → null).
- `CompareAsIntegerKeysTest` — length-mismatch guard + non-4/8-byte lexicographic fallback for the integer-key comparators.
- `KeyRangeBuilderTest` — builder/prefix/inclusive accessors + derived `KeyRangeType`.
- `LmdbStreamCharacteristicsTest` — locks in the corrected spliterator contract.
- `DbiIterateApiTest` — `newIterate(EntryConsumer)` overloads, ranged stream, `LmdbIterable` single-use, `getNameAsString`, `toString`.
- `LmdbPrefixReversedSuccessorTest` — the reverse-prefix regression above.

## Verification
Full test suite (excluding the pre-existing, environment-flaky `TestLmdbStreamBenchmark`, which fails at `Env.open` unrelated to these changes): **1687 tests, 0 failures**. `mvn fmt:check` is clean for all touched files. Java 8 source level unchanged.

## Deliberately left open (branch decisions, not addressed here)
These came up while reviewing the branch and are for the maintainers, not this PR:
- Approach approval; renaming the placeholder `newIterate(...)` and retiring/adapting `CursorIterable` for API compatibility.
- Whether to split the bundled FlagSet / DbiBuilder / ByteUnit / gh-249 / gh-267 work from the iterator perf change.
- Rebasing onto current `master`; squashing WIP history and purging the accidentally-committed native binaries (`src/main/resources/org/lmdbjava/*.so|*.dll`) that live in branch history.
- Codecov gate (new `Env`/`Dbi`/`Cursor` methods still thinly covered) and the remaining code-scanning alerts (deprecated `Env.openDbi` in tests, `NumberFormatException` in CSV parsing, field shadowing) — some intentionally not touched here as they live in branch-owned test helpers.
- The `KeyVal`-snapshot redesign that would let `SORTED` + a real comparator return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)